### PR TITLE
Add libclang AST analysis, syntect highlighting, and expanded editor …

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,6 +362,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "gobject-sys"
 version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,6 +459,16 @@ name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
 
 [[package]]
 name = "libsqlite3-sys"
@@ -639,6 +666,7 @@ version = "0.1.0"
 dependencies = [
  "cairo-rs",
  "cairo-sys-rs",
+ "clang-sys",
  "env_logger",
  "log",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 syntect = "5"
 
 # Phase 6: AST analysis (libclang)
-# clang-sys = { version = "1", features = ["clang_17_0"] }
+clang-sys = { version = "1", features = ["clang_18_0", "runtime"] }
 
 # Utilities
 log = "0.4"

--- a/src/analysis/ast_analyzer.rs
+++ b/src/analysis/ast_analyzer.rs
@@ -1,16 +1,59 @@
-/// AST analysis engine (Phase 6 - stub).
-/// Will use libclang to analyze code relationships from error locations.
+/// AST analysis engine using libclang.
+/// Analyzes code at error locations and discovers related symbols (calls, refs, includes).
+
+#[allow(non_upper_case_globals)]
+mod inner {
+    pub use clang_sys::*;
+}
+use inner::*;
 
 use crate::core::types::*;
+use std::collections::HashMap;
+use std::ffi::{CStr, CString};
+use std::path::Path;
+use std::ptr;
 
 pub struct AstAnalyzer {
+    index: CXIndex,
     build_dir: String,
+    tu_cache: HashMap<String, CXTranslationUnit>,
+    next_id: u32,
+    loaded: bool,
+}
+
+/// Reference discovered during AST traversal.
+struct SymbolRef {
+    file: String,
+    line: u32,
+    column: u32,
+    name: String,
+    node_type: NodeType,
+    edge_type: EdgeType,
+}
+
+/// Context passed to the visitor callback.
+struct VisitorContext {
+    refs: Vec<SymbolRef>,
+    origin_file: String,
 }
 
 impl AstAnalyzer {
     pub fn new() -> Self {
+        // Load libclang shared library at runtime
+        let loaded = load().is_ok();
+        let index = if loaded {
+            unsafe { clang_createIndex(0, 0) }
+        } else {
+            log::warn!("Failed to load libclang — AST analysis disabled");
+            ptr::null_mut()
+        };
+
         Self {
+            index,
             build_dir: ".".to_string(),
+            tu_cache: HashMap::new(),
+            next_id: 1000,
+            loaded,
         }
     }
 
@@ -18,19 +61,482 @@ impl AstAnalyzer {
         self.build_dir = build_dir.to_string();
     }
 
+    pub fn set_next_id_start(&mut self, start: u32) {
+        self.next_id = start;
+    }
+
+    fn alloc_id(&mut self) -> u32 {
+        let id = self.next_id;
+        self.next_id += 1;
+        id
+    }
+
     /// Analyze an error location and add related nodes/edges to the graph.
-    /// Phase 6: Will use libclang for real AST traversal.
-    pub fn analyze_error_location(&self, _error: &ErrorInfo, _graph: &mut RelayGraph) {
-        // TODO Phase 6: Implement with clang-sys
-        // 1. Parse TU with clang_parseTranslationUnit
-        // 2. Get cursor at error location
-        // 3. Collect references (calls, types, includes)
-        // 4. Add nodes and edges to graph
+    pub fn analyze_error_location(
+        &mut self,
+        error: &ErrorInfo,
+        error_node_id: u32,
+        graph: &mut RelayGraph,
+    ) {
+        if !self.loaded || self.index.is_null() {
+            return;
+        }
+        if !Path::new(&error.file_path).exists() {
+            return;
+        }
+
+        let tu = match self.get_or_parse_tu(&error.file_path) {
+            Some(tu) => tu,
+            None => return,
+        };
+
+        // Get cursor at the error location
+        let cursor = unsafe {
+            let file = {
+                let path = CString::new(error.file_path.as_str()).unwrap();
+                clang_getFile(tu, path.as_ptr())
+            };
+            if file.is_null() {
+                return;
+            }
+
+            let location = clang_getLocation(tu, file, error.line, error.column.max(1));
+            clang_getCursor(tu, location)
+        };
+
+        if unsafe { clang_Cursor_isNull(cursor) } != 0 {
+            return;
+        }
+
+        // Try to get the referenced/defined symbol
+        let referenced = unsafe { clang_getCursorReferenced(cursor) };
+        if unsafe { clang_Cursor_isNull(referenced) } == 0 {
+            if let Some(sym_ref) = self.cursor_to_symbol_ref(referenced, EdgeType::Reference) {
+                if sym_ref.file != error.file_path || sym_ref.line != error.line {
+                    let ref_id = self.alloc_id();
+                    let mut node = GraphNode::new(ref_id, &sym_ref.name, sym_ref.node_type);
+                    node.file_path = sym_ref.file;
+                    node.line = sym_ref.line;
+                    node.column = sym_ref.column;
+                    graph.nodes.push(node);
+                    graph.edges.push(GraphEdge {
+                        source_id: error_node_id,
+                        target_id: ref_id,
+                        edge_type: sym_ref.edge_type,
+                        on_error_path: true,
+                    });
+                }
+            }
+        }
+
+        // Collect child references via visitor
+        let mut ctx = VisitorContext {
+            refs: Vec::new(),
+            origin_file: error.file_path.clone(),
+        };
+
+        // Get the parent function/method for broader context
+        let semantic_parent = unsafe { clang_getCursorSemanticParent(cursor) };
+        let visit_cursor =
+            if unsafe { clang_Cursor_isNull(semantic_parent) } == 0
+                && is_function_like(unsafe { clang_getCursorKind(semantic_parent) })
+            {
+                semantic_parent
+            } else {
+                cursor
+            };
+
+        unsafe {
+            clang_visitChildren(
+                visit_cursor,
+                visit_children_callback,
+                &mut ctx as *mut VisitorContext as CXClientData,
+            );
+        }
+
+        // Deduplicate and add discovered references
+        let mut seen: HashMap<(String, u32), u32> = HashMap::new();
+
+        // Register existing nodes to avoid duplicates
+        for node in &graph.nodes {
+            seen.insert((node.file_path.clone(), node.line), node.id);
+        }
+
+        for sym_ref in &ctx.refs {
+            let key = (sym_ref.file.clone(), sym_ref.line);
+            if let Some(&existing_id) = seen.get(&key) {
+                // Add edge to existing node if not already connected
+                let already_connected = graph.edges.iter().any(|e| {
+                    (e.source_id == error_node_id && e.target_id == existing_id)
+                        || (e.source_id == existing_id && e.target_id == error_node_id)
+                });
+                if !already_connected {
+                    graph.edges.push(GraphEdge {
+                        source_id: error_node_id,
+                        target_id: existing_id,
+                        edge_type: sym_ref.edge_type,
+                        on_error_path: false,
+                    });
+                }
+            } else {
+                let new_id = self.alloc_id();
+                let mut node = GraphNode::new(new_id, &sym_ref.name, sym_ref.node_type);
+                node.file_path = sym_ref.file.clone();
+                node.line = sym_ref.line;
+                node.column = sym_ref.column;
+                graph.nodes.push(node);
+                graph.edges.push(GraphEdge {
+                    source_id: error_node_id,
+                    target_id: new_id,
+                    edge_type: sym_ref.edge_type,
+                    on_error_path: false,
+                });
+                seen.insert(key, new_id);
+            }
+        }
+    }
+
+    /// Parse (or retrieve from cache) a translation unit.
+    fn get_or_parse_tu(&mut self, file_path: &str) -> Option<CXTranslationUnit> {
+        if let Some(&tu) = self.tu_cache.get(file_path) {
+            return Some(tu);
+        }
+
+        let args = self.get_compile_args(file_path);
+        let c_args: Vec<CString> = args.iter().map(|a| CString::new(a.as_str()).unwrap()).collect();
+        let c_arg_ptrs: Vec<*const i8> = c_args.iter().map(|a| a.as_ptr()).collect();
+
+        let c_file = CString::new(file_path).unwrap();
+
+        let tu = unsafe {
+            clang_parseTranslationUnit(
+                self.index,
+                c_file.as_ptr(),
+                c_arg_ptrs.as_ptr(),
+                c_arg_ptrs.len() as i32,
+                ptr::null_mut(),
+                0,
+                CXTranslationUnit_DetailedPreprocessingRecord,
+            )
+        };
+
+        if tu.is_null() {
+            log::warn!("Failed to parse TU: {}", file_path);
+            return None;
+        }
+
+        self.tu_cache.insert(file_path.to_string(), tu);
+        Some(tu)
+    }
+
+    /// Get compilation arguments for a file, attempting compile_commands.json first.
+    fn get_compile_args(&self, file_path: &str) -> Vec<String> {
+        // Try to load from compile_commands.json
+        let compile_commands_path = format!("{}/compile_commands.json", self.build_dir);
+        if Path::new(&compile_commands_path).exists() {
+            if let Some(args) = self.load_args_from_compdb(file_path) {
+                return args;
+            }
+        }
+
+        // Fallback: default C++ flags
+        let ext = Path::new(file_path)
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("");
+
+        match ext {
+            "c" => vec!["-std=c11".to_string()],
+            "cs" => vec![], // C# not handled by libclang
+            _ => vec!["-std=c++17".to_string(), "-x".to_string(), "c++".to_string()],
+        }
+    }
+
+    /// Parse compile_commands.json to find arguments for a specific file.
+    fn load_args_from_compdb(&self, file_path: &str) -> Option<Vec<String>> {
+        let db_path = CString::new(self.build_dir.as_str()).ok()?;
+        let mut error = unsafe { clang_CompilationDatabase_fromDirectory(db_path.as_ptr(), ptr::null_mut()) };
+
+        if error.is_null() {
+            return None;
+        }
+
+        let c_file = CString::new(file_path).ok()?;
+        let commands = unsafe {
+            clang_CompilationDatabase_getCompileCommands(error, c_file.as_ptr())
+        };
+
+        let result = if !commands.is_null() {
+            let n = unsafe { clang_CompileCommands_getSize(commands) };
+            if n > 0 {
+                let cmd = unsafe { clang_CompileCommands_getCommand(commands, 0) };
+                let nargs = unsafe { clang_CompileCommand_getNumArgs(cmd) };
+                let mut args = Vec::new();
+                // Skip first arg (compiler) and last arg (source file)
+                for i in 1..nargs.saturating_sub(1) {
+                    let arg = unsafe { clang_CompileCommand_getArg(cmd, i) };
+                    let arg_str = cx_string_to_string(arg);
+                    // Skip output-related flags
+                    if arg_str != "-o" && !arg_str.ends_with(".o") && arg_str != "-c" {
+                        args.push(arg_str);
+                    }
+                }
+                Some(args)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        unsafe {
+            if !commands.is_null() {
+                clang_CompileCommands_dispose(commands);
+            }
+            clang_CompilationDatabase_dispose(error);
+        }
+
+        result
+    }
+
+    /// Convert a cursor to a SymbolRef.
+    fn cursor_to_symbol_ref(&self, cursor: CXCursor, edge_type: EdgeType) -> Option<SymbolRef> {
+        let location = unsafe { clang_getCursorLocation(cursor) };
+
+        let mut file: CXFile = ptr::null_mut();
+        let mut line: u32 = 0;
+        let mut column: u32 = 0;
+
+        unsafe {
+            clang_getFileLocation(location, &mut file, &mut line, &mut column, ptr::null_mut());
+        }
+
+        if file.is_null() || line == 0 {
+            return None;
+        }
+
+        let file_name = cx_string_to_string(unsafe { clang_getFileName(file) });
+        let cursor_name = cx_string_to_string(unsafe { clang_getCursorSpelling(cursor) });
+        let kind = unsafe { clang_getCursorKind(cursor) };
+
+        let node_type = cursor_kind_to_node_type(kind);
+
+        Some(SymbolRef {
+            file: file_name,
+            line,
+            column,
+            name: cursor_name,
+            node_type,
+            edge_type,
+        })
     }
 }
 
 impl Default for AstAnalyzer {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl Drop for AstAnalyzer {
+    fn drop(&mut self) {
+        if !self.loaded {
+            return;
+        }
+        for (_, tu) in self.tu_cache.drain() {
+            unsafe {
+                clang_disposeTranslationUnit(tu);
+            }
+        }
+        if !self.index.is_null() {
+            unsafe {
+                clang_disposeIndex(self.index);
+            }
+        }
+    }
+}
+
+// ===== Helper functions =====
+
+/// Convert a CXString to an owned String.
+fn cx_string_to_string(cx_str: CXString) -> String {
+    unsafe {
+        let c_str = clang_getCString(cx_str);
+        let result = if c_str.is_null() {
+            String::new()
+        } else {
+            CStr::from_ptr(c_str).to_string_lossy().into_owned()
+        };
+        clang_disposeString(cx_str);
+        result
+    }
+}
+
+/// Map clang cursor kind to our NodeType.
+fn cursor_kind_to_node_type(kind: CXCursorKind) -> NodeType {
+    match kind {
+        CXCursor_FunctionDecl
+        | CXCursor_CXXMethod
+        | CXCursor_Constructor
+        | CXCursor_Destructor
+        | CXCursor_FunctionTemplate => NodeType::Function,
+
+        CXCursor_ClassDecl
+        | CXCursor_StructDecl
+        | CXCursor_EnumDecl
+        | CXCursor_TypedefDecl
+        | CXCursor_TypeAliasDecl
+        | CXCursor_ClassTemplate => NodeType::Type,
+
+        CXCursor_VarDecl | CXCursor_FieldDecl | CXCursor_ParmDecl => NodeType::Variable,
+
+        CXCursor_InclusionDirective => NodeType::Include,
+
+        _ => NodeType::Variable,
+    }
+}
+
+/// Check if a cursor kind represents a function-like entity.
+fn is_function_like(kind: CXCursorKind) -> bool {
+    matches!(
+        kind,
+        CXCursor_FunctionDecl
+            | CXCursor_CXXMethod
+            | CXCursor_Constructor
+            | CXCursor_Destructor
+            | CXCursor_FunctionTemplate
+    )
+}
+
+/// Map cursor kind of a reference/expression to the appropriate EdgeType.
+fn cursor_kind_to_edge_type(kind: CXCursorKind) -> EdgeType {
+    match kind {
+        CXCursor_CallExpr => EdgeType::Call,
+        CXCursor_CXXBaseSpecifier => EdgeType::Inherit,
+        CXCursor_InclusionDirective => EdgeType::Include,
+        CXCursor_TypeRef | CXCursor_TemplateRef => EdgeType::Reference,
+        CXCursor_DeclRefExpr | CXCursor_MemberRefExpr => EdgeType::Reference,
+        _ => EdgeType::Reference,
+    }
+}
+
+/// Visitor callback for clang_visitChildren.
+extern "C" fn visit_children_callback(
+    cursor: CXCursor,
+    _parent: CXCursor,
+    client_data: CXClientData,
+) -> CXChildVisitResult {
+    let ctx = unsafe { &mut *(client_data as *mut VisitorContext) };
+    let kind = unsafe { clang_getCursorKind(cursor) };
+
+    let should_collect = matches!(
+        kind,
+        CXCursor_CallExpr
+            | CXCursor_DeclRefExpr
+            | CXCursor_MemberRefExpr
+            | CXCursor_TypeRef
+            | CXCursor_TemplateRef
+            | CXCursor_CXXBaseSpecifier
+            | CXCursor_InclusionDirective
+    );
+
+    if should_collect {
+        // Get the referenced declaration
+        let referenced = unsafe { clang_getCursorReferenced(cursor) };
+        let target = if unsafe { clang_Cursor_isNull(referenced) } == 0 {
+            referenced
+        } else {
+            cursor
+        };
+
+        let location = unsafe { clang_getCursorLocation(target) };
+
+        let mut file: CXFile = ptr::null_mut();
+        let mut line: u32 = 0;
+        let mut column: u32 = 0;
+
+        unsafe {
+            clang_getFileLocation(location, &mut file, &mut line, &mut column, ptr::null_mut());
+        }
+
+        if !file.is_null() && line > 0 {
+            let file_name = cx_string_to_string(unsafe { clang_getFileName(file) });
+            let name = cx_string_to_string(unsafe { clang_getCursorSpelling(target) });
+
+            // Skip system headers and self-references
+            if !file_name.starts_with("/usr/") && !name.is_empty() {
+                let ref_kind = unsafe { clang_getCursorKind(target) };
+                ctx.refs.push(SymbolRef {
+                    file: file_name,
+                    line,
+                    column,
+                    name,
+                    node_type: cursor_kind_to_node_type(ref_kind),
+                    edge_type: cursor_kind_to_edge_type(kind),
+                });
+            }
+        }
+    }
+
+    CXChildVisit_Recurse
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn test_analyzer_creation() {
+        let analyzer = AstAnalyzer::new();
+        assert!(!analyzer.index.is_null());
+    }
+
+    #[test]
+    fn test_analyze_simple_file() {
+        let mut analyzer = AstAnalyzer::new();
+        let mut graph = RelayGraph::default();
+
+        // Create a temporary C++ file
+        let dir = std::env::temp_dir().join("relay_test_ast");
+        std::fs::create_dir_all(&dir).ok();
+        let file_path = dir.join("test.cpp");
+        let mut f = std::fs::File::create(&file_path).unwrap();
+        writeln!(
+            f,
+            r#"
+void helper() {{}}
+
+void broken_func() {{
+    helper();
+    int x = 42;
+}}
+"#
+        )
+        .unwrap();
+
+        let error = ErrorInfo {
+            file_path: file_path.to_string_lossy().to_string(),
+            line: 4,
+            column: 1,
+            error_code: String::new(),
+            message: "test error".to_string(),
+        };
+
+        // Add the error node first
+        let error_node = GraphNode::new(0, "test error", NodeType::ErrorSource);
+        graph.nodes.push(error_node);
+
+        analyzer.analyze_error_location(&error, 0, &mut graph);
+
+        // Should have found at least the helper() call reference
+        assert!(
+            graph.nodes.len() > 1,
+            "Expected AST analysis to find references, got {} nodes",
+            graph.nodes.len()
+        );
+
+        // Clean up
+        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/src/editor/editor_view.rs
+++ b/src/editor/editor_view.rs
@@ -1,44 +1,76 @@
-/// Editor view using syntect for syntax highlighting, rendered via Cairo.
+/// Editor view with syntect syntax highlighting, rendered via Cairo.
 
 use crate::core::config;
 use crate::core::types::Color;
 use crate::platform::renderer::Renderer;
+use std::path::Path;
+use syntect::highlighting::{self, ThemeSet};
+use syntect::parsing::SyntaxSet;
+
+/// A single highlighted token with position and color.
+struct HighlightedToken {
+    text: String,
+    color: Color,
+}
+
+/// Pre-highlighted line: sequence of colored tokens.
+struct HighlightedLine {
+    tokens: Vec<HighlightedToken>,
+}
 
 pub struct EditorView {
     lines: Vec<String>,
+    highlighted: Vec<HighlightedLine>,
     file_path: String,
     scroll_offset: usize,
     highlight_line: Option<u32>,
     visible: bool,
+    syntax_set: SyntaxSet,
+    theme: highlighting::Theme,
 }
 
 impl EditorView {
     pub fn new() -> Self {
+        let syntax_set = SyntaxSet::load_defaults_newlines();
+        let theme_set = ThemeSet::load_defaults();
+        // Use a dark theme that matches our color scheme
+        let theme = theme_set
+            .themes
+            .get("base16-ocean.dark")
+            .cloned()
+            .unwrap_or_else(|| theme_set.themes.values().next().unwrap().clone());
+
         Self {
             lines: Vec::new(),
+            highlighted: Vec::new(),
             file_path: String::new(),
             scroll_offset: 0,
             highlight_line: None,
             visible: false,
+            syntax_set,
+            theme,
         }
     }
 
     pub fn load_file(&mut self, path: &str) -> bool {
-        match std::fs::read_to_string(path) {
-            Ok(content) => {
-                self.lines = content.lines().map(|l| l.to_string()).collect();
-                self.file_path = path.to_string();
-                self.scroll_offset = 0;
-                true
-            }
-            Err(_) => false,
-        }
+        let content = match std::fs::read_to_string(path) {
+            Ok(c) => c,
+            Err(_) => return false,
+        };
+
+        self.lines = content.lines().map(|l| l.to_string()).collect();
+        self.file_path = path.to_string();
+        self.scroll_offset = 0;
+
+        // Syntax highlight all lines
+        self.highlight_content(&content, path);
+
+        true
     }
 
     pub fn goto_line(&mut self, line: u32) {
         if line > 0 {
             let target = (line as usize).saturating_sub(1);
-            // Center the target line in the view
             self.scroll_offset = target.saturating_sub(10);
         }
     }
@@ -62,12 +94,13 @@ impl EditorView {
         }
 
         // Background
-        renderer.fill_rect(x, y, w, h, Color::from_hex(config::NODE_BG, 1.0));
+        renderer.fill_rect(x, y, w, h, Color::from_hex(0x0D1117, 1.0));
 
         let line_height = 16.0;
         let font_size = 12.0;
         let gutter_width = 48.0;
-        let max_visible = ((h / line_height) as usize).min(self.lines.len() - self.scroll_offset);
+        let visible_lines = (h / line_height) as usize;
+        let max_visible = visible_lines.min(self.lines.len().saturating_sub(self.scroll_offset));
 
         for i in 0..max_visible {
             let line_idx = self.scroll_offset + i;
@@ -77,20 +110,21 @@ impl EditorView {
 
             let ly = y + i as f64 * line_height;
 
-            // Highlight error line
+            // Error line highlight
             if self.highlight_line == Some((line_idx + 1) as u32) {
                 renderer.fill_rect(x, ly, w, line_height, Color::from_hex(0x3D1E28, 0.6));
+                // Error line indicator bar
+                renderer.fill_rect(x, ly, 3.0, line_height, Color::from_hex(config::ERROR_BORDER, 0.9));
             }
 
             // Line number
             let line_num = format!("{:>4}", line_idx + 1);
-            renderer.draw_text(
-                x + 4.0,
-                ly + 2.0,
-                &line_num,
-                font_size,
-                Color::from_hex(config::TEXT_SECONDARY, 0.7),
-            );
+            let ln_color = if self.highlight_line == Some((line_idx + 1) as u32) {
+                Color::from_hex(config::ERROR_BORDER, 0.8)
+            } else {
+                Color::from_hex(config::TEXT_SECONDARY, 0.5)
+            };
+            renderer.draw_text(x + 4.0, ly + 2.0, &line_num, font_size, ln_color);
 
             // Gutter separator
             renderer.fill_rect(
@@ -101,21 +135,76 @@ impl EditorView {
                 Color::from_hex(config::NODE_BORDER, 0.3),
             );
 
-            // Code text (basic - Phase 3 will add syntect highlighting)
-            let line_text = &self.lines[line_idx];
-            let display = if line_text.len() > 80 {
-                &line_text[..80]
+            // Syntax-highlighted code text
+            let code_x = x + gutter_width + 4.0;
+            if line_idx < self.highlighted.len() {
+                let hl_line = &self.highlighted[line_idx];
+                let mut cx = code_x;
+                for token in &hl_line.tokens {
+                    renderer.draw_text(cx, ly + 2.0, &token.text, font_size, token.color);
+                    // Approximate character width for monospace font
+                    cx += token.text.len() as f64 * 7.2;
+                }
             } else {
-                line_text
-            };
+                // Fallback: uncolored text
+                let line_text = &self.lines[line_idx];
+                let display = if line_text.len() > 80 {
+                    &line_text[..80]
+                } else {
+                    line_text
+                };
+                renderer.draw_text(
+                    code_x,
+                    ly + 2.0,
+                    display,
+                    font_size,
+                    Color::from_hex(config::TEXT_PRIMARY, 1.0),
+                );
+            }
+        }
+    }
 
-            renderer.draw_text(
-                x + gutter_width + 4.0,
-                ly + 2.0,
-                display,
-                font_size,
-                Color::from_hex(config::TEXT_PRIMARY, 1.0),
-            );
+    /// Perform syntax highlighting on the full file content.
+    fn highlight_content(&mut self, content: &str, file_path: &str) {
+        let ext = Path::new(file_path)
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("txt");
+
+        let syntax = self
+            .syntax_set
+            .find_syntax_by_extension(ext)
+            .unwrap_or_else(|| self.syntax_set.find_syntax_plain_text());
+
+        let mut highlighter = syntect::easy::HighlightLines::new(syntax, &self.theme);
+
+        self.highlighted.clear();
+        for line in content.lines() {
+            let line_with_nl = format!("{}\n", line);
+            match highlighter.highlight_line(&line_with_nl, &self.syntax_set) {
+                Ok(ranges) => {
+                    let tokens: Vec<HighlightedToken> = ranges
+                        .iter()
+                        .map(|(style, text)| {
+                            let text = text.trim_end_matches('\n').to_string();
+                            HighlightedToken {
+                                text,
+                                color: syntect_color_to_color(style.foreground),
+                            }
+                        })
+                        .filter(|t| !t.text.is_empty())
+                        .collect();
+                    self.highlighted.push(HighlightedLine { tokens });
+                }
+                Err(_) => {
+                    self.highlighted.push(HighlightedLine {
+                        tokens: vec![HighlightedToken {
+                            text: line.to_string(),
+                            color: Color::from_hex(config::TEXT_PRIMARY, 1.0),
+                        }],
+                    });
+                }
+            }
         }
     }
 }
@@ -123,5 +212,14 @@ impl EditorView {
 impl Default for EditorView {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+fn syntect_color_to_color(c: highlighting::Color) -> Color {
+    Color {
+        r: c.r as f64 / 255.0,
+        g: c.g as f64 / 255.0,
+        b: c.b as f64 / 255.0,
+        a: c.a as f64 / 255.0,
     }
 }

--- a/src/graph/graph_view.rs
+++ b/src/graph/graph_view.rs
@@ -1,7 +1,9 @@
 /// Main graph view: camera management, node interaction, and rendering coordination.
+/// Integrates EditorView for expanded node display.
 
 use crate::core::config;
 use crate::core::types::*;
+use crate::editor::editor_view::EditorView;
 use crate::graph::animation::{lerp, smooth_towards, Animation};
 use crate::graph::graph_edge::GraphEdgeRenderer;
 use crate::graph::graph_node::GraphNodeRenderer;
@@ -22,12 +24,17 @@ pub struct GraphView {
     // Node interaction
     hovered_node_id: Option<u32>,
     selected_node_id: Option<u32>,
-    hover_values: Vec<f64>, // per-node hover animation value (0..1)
+    hover_values: Vec<f64>,
 
     // Expand/collapse animation
     expand_anim: Animation,
     collapse_anim: Animation,
     expanding_node_id: Option<u32>,
+    // Store original position/size for animation
+    expand_origin: (f64, f64, f64, f64), // (x, y, w, h)
+
+    // Embedded editor for expanded nodes
+    editor: EditorView,
 
     // Renderers
     node_renderer: GraphNodeRenderer,
@@ -35,6 +42,10 @@ pub struct GraphView {
 
     // Timing
     time_sec: f64,
+
+    // View dimensions (updated on render)
+    view_width: f64,
+    view_height: f64,
 }
 
 impl GraphView {
@@ -52,9 +63,13 @@ impl GraphView {
             expand_anim: Animation::new(),
             collapse_anim: Animation::new(),
             expanding_node_id: None,
+            expand_origin: (0.0, 0.0, 0.0, 0.0),
+            editor: EditorView::new(),
             node_renderer: GraphNodeRenderer::new(),
             edge_renderer: GraphEdgeRenderer::new(),
             time_sec: 0.0,
+            view_width: 1280.0,
+            view_height: 720.0,
         }
     }
 
@@ -76,7 +91,6 @@ impl GraphView {
             self.zoom = (self.zoom + e.scroll_y * config::ZOOM_SPEED)
                 .clamp(config::ZOOM_MIN, config::ZOOM_MAX);
 
-            // Zoom centered on cursor
             let mouse = Vec2::new(e.x, e.y);
             self.camera_offset = mouse - (mouse - self.camera_offset) * (self.zoom / zoom_old);
             return;
@@ -112,12 +126,10 @@ impl GraphView {
         if e.button == 1 && e.pressed {
             if let Some(hovered) = self.hovered_node_id {
                 if self.selected_node_id == Some(hovered) {
-                    // Already selected, toggle expand
                     if self.expanding_node_id.is_some() {
                         self.collapse_node();
                     }
                 } else {
-                    // Select and expand
                     if self.expanding_node_id.is_some() {
                         self.collapse_node();
                     }
@@ -125,7 +137,6 @@ impl GraphView {
                     self.expand_node(hovered);
                 }
             } else {
-                // Click on empty space
                 if self.expanding_node_id.is_some() {
                     self.collapse_node();
                 }
@@ -139,7 +150,7 @@ impl GraphView {
             return;
         }
 
-        // ESC: collapse or quit signal
+        // ESC: collapse expanded node
         if e.keycode == 9 {
             if self.expanding_node_id.is_some() {
                 self.collapse_node();
@@ -147,7 +158,7 @@ impl GraphView {
         }
 
         // Space: fit all
-        if e.keycode == 65 {
+        if e.keycode == 65 && self.expanding_node_id.is_none() {
             self.fit_all();
         }
 
@@ -155,18 +166,31 @@ impl GraphView {
         if e.keycode == 23 {
             self.focus_next_error();
         }
-
-        // Ctrl+Q: quit (handled externally)
     }
 
     pub fn update(&mut self, dt_ms: f64) {
         self.time_sec += dt_ms / 1000.0;
 
-        // Update expand/collapse animations
         self.expand_anim.update(dt_ms);
         self.collapse_anim.update(dt_ms);
 
-        // Update hover interpolation
+        // When expand animation completes, load editor content
+        if self.expand_anim.progress() >= 0.99 && !self.editor.is_visible() {
+            if let Some(id) = self.expanding_node_id {
+                if let Some(node) = self.graph.find_node(id) {
+                    if !node.file_path.is_empty() {
+                        self.editor.load_file(&node.file_path);
+                        self.editor.goto_line(node.line);
+                        if node.is_error {
+                            self.editor.set_highlight_line(node.line);
+                        }
+                        self.editor.set_visible(true);
+                    }
+                }
+            }
+        }
+
+        // Hover interpolation
         for (i, node) in self.graph.nodes.iter().enumerate() {
             if i >= self.hover_values.len() {
                 break;
@@ -181,12 +205,16 @@ impl GraphView {
     }
 
     pub fn render(&self, renderer: &dyn Renderer) {
-        // Apply camera transform
         renderer.push_transform(self.camera_offset, self.zoom);
 
         let is_expanding = self.expanding_node_id.is_some();
+        let expand_t = if is_expanding {
+            self.expand_anim.progress()
+        } else {
+            0.0
+        };
 
-        // Render edges first (behind nodes)
+        // Render edges (behind nodes)
         for edge in &self.graph.edges {
             let source = match self.graph.find_node(edge.source_id) {
                 Some(n) => n,
@@ -220,22 +248,105 @@ impl GraphView {
                 0.0
             };
 
-            let focus_t = if is_expanding {
-                let expanding_id = self.expanding_node_id.unwrap();
-                if node.id == expanding_id {
-                    0.0
-                } else {
-                    self.expand_anim.progress()
-                }
-            } else {
-                0.0
-            };
+            let is_expanded_node = self.expanding_node_id == Some(node.id);
 
-            self.node_renderer
-                .render_collapsed(renderer, node, hover_t, focus_t);
+            if is_expanded_node && expand_t > 0.01 {
+                // Render expanding/expanded node
+                self.render_expanded_node(renderer, node, expand_t);
+            } else {
+                let focus_t = if is_expanding && !is_expanded_node {
+                    expand_t
+                } else {
+                    0.0
+                };
+
+                self.node_renderer
+                    .render_collapsed(renderer, node, hover_t, focus_t);
+            }
         }
 
         renderer.pop_transform();
+    }
+
+    /// Render a node in its expanded state with editor view.
+    fn render_expanded_node(&self, renderer: &dyn Renderer, node: &GraphNode, t: f64) {
+        let (ox, oy, ow, oh) = self.expand_origin;
+        let target_w = config::NODE_EXPANDED_W;
+        let target_h = config::NODE_EXPANDED_H;
+        // Center expanded node on its original position
+        let target_x = ox + (ow - target_w) / 2.0;
+        let target_y = oy + (oh - target_h) / 2.0;
+
+        let x = lerp(ox, target_x, t);
+        let y = lerp(oy, target_y, t);
+        let w = lerp(ow, target_w, t);
+        let h = lerp(oh, target_h, t);
+        let r = config::NODE_CORNER_RADIUS;
+
+        // Shadow
+        renderer.draw_shadow(
+            x,
+            y,
+            w,
+            h,
+            r,
+            Color {
+                r: 0.0,
+                g: 0.0,
+                b: 0.0,
+                a: 0.6 * t,
+            },
+            12.0 * t,
+        );
+
+        // Error glow
+        if node.is_error {
+            renderer.draw_shadow(x, y, w, h, r, Color::from_hex(config::ERROR_BORDER, 0.4 * t), 12.0);
+        }
+
+        // Background
+        renderer.fill_rounded_rect(x, y, w, h, r, Color::from_hex(config::NODE_BG, 1.0));
+
+        // Border
+        let border_color = if node.is_error {
+            Color::from_hex(config::ERROR_BORDER, 1.0)
+        } else {
+            Color::from_hex(config::EDGE_CALL, 0.8)
+        };
+        renderer.stroke_rounded_rect(x, y, w, h, r, border_color, 2.0);
+
+        // Header
+        let filename = node
+            .file_path
+            .rsplit('/')
+            .next()
+            .unwrap_or(&node.file_path);
+        let header = format!("{}:{} — {}", filename, node.line, node.symbol_name);
+        renderer.draw_text(
+            x + 12.0,
+            y + 8.0,
+            &header,
+            13.0,
+            Color::from_hex(config::TEXT_PRIMARY, 1.0),
+        );
+
+        // Separator
+        renderer.fill_rect(
+            x + 8.0,
+            y + 28.0,
+            w - 16.0,
+            1.0,
+            Color::from_hex(config::NODE_BORDER, 0.6),
+        );
+
+        // Editor content (rendered when animation completes)
+        if t > 0.95 {
+            let editor_x = x + 4.0;
+            let editor_y = y + 32.0;
+            let editor_w = w - 8.0;
+            let editor_h = h - 36.0;
+            self.editor.render(renderer, editor_x, editor_y, editor_w, editor_h);
+        }
     }
 
     // ===== Private helpers =====
@@ -247,19 +358,18 @@ impl GraphView {
         }
     }
 
-    fn _graph_to_screen(&self, graph: Vec2) -> Vec2 {
-        Vec2 {
-            x: graph.x * self.zoom + self.camera_offset.x,
-            y: graph.y * self.zoom + self.camera_offset.y,
-        }
-    }
-
     fn expand_node(&mut self, id: u32) {
+        // Store original position for animation
+        if let Some(node) = self.graph.find_node(id) {
+            self.expand_origin = (node.x, node.y, node.width, node.height);
+        }
         self.expanding_node_id = Some(id);
         self.expand_anim.start(config::ANIM_EXPAND_MS);
+        self.editor.set_visible(false);
     }
 
     fn collapse_node(&mut self) {
+        self.editor.set_visible(false);
         self.expanding_node_id = None;
         self.collapse_anim.start(config::ANIM_EXPAND_MS);
         self.selected_node_id = None;
@@ -285,14 +395,12 @@ impl GraphView {
         let graph_w = max_x - min_x + 100.0;
         let graph_h = max_y - min_y + 100.0;
 
-        // This would need window dimensions; approximate with 1280x720
-        let view_w = 1280.0;
-        let view_h = 720.0;
-
-        self.zoom = (view_w / graph_w).min(view_h / graph_h).min(config::ZOOM_MAX);
+        self.zoom = (self.view_width / graph_w)
+            .min(self.view_height / graph_h)
+            .min(config::ZOOM_MAX);
         self.camera_offset = Vec2 {
-            x: view_w / 2.0 - (min_x + graph_w / 2.0) * self.zoom,
-            y: view_h / 2.0 - (min_y + graph_h / 2.0) * self.zoom,
+            x: self.view_width / 2.0 - (min_x + graph_w / 2.0) * self.zoom,
+            y: self.view_height / 2.0 - (min_y + graph_h / 2.0) * self.zoom,
         };
     }
 
@@ -320,11 +428,17 @@ impl GraphView {
             self.selected_node_id = Some(id);
             if let Some(node) = self.graph.find_node(id) {
                 self.camera_offset = Vec2 {
-                    x: 640.0 - node.x * self.zoom,
-                    y: 360.0 - node.y * self.zoom,
+                    x: self.view_width / 2.0 - node.x * self.zoom,
+                    y: self.view_height / 2.0 - node.y * self.zoom,
                 };
             }
         }
+    }
+
+    /// Update the known view dimensions (called from main loop).
+    pub fn set_view_size(&mut self, width: f64, height: f64) {
+        self.view_width = width;
+        self.view_height = height;
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,6 +132,7 @@ fn main() {
         let dt = now.duration_since(last_time).as_secs_f64() * 1000.0;
         last_time = now;
 
+        graph_view.set_view_size(window.width() as f64, window.height() as f64);
         graph_view.update(dt);
 
         // Render


### PR DESCRIPTION
…view

- Phase 6: Full AST analysis engine using clang-sys
  - Parses C/C++ files via libclang to discover symbol references
  - Finds call expressions, type refs, includes, inheritance
  - TU caching, compile_commands.json support
  - Filters system headers, deduplicates nodes

- Syntect integration for syntax highlighting in EditorView
  - Auto-detects language from file extension
  - Per-token colored rendering with base16-ocean.dark theme
  - Error line highlighting with red indicator bar

- Expanded node editor integration in GraphView
  - Click node → animated expand → shows syntax-highlighted code
  - Error line highlighted, auto-scrolled to error location
  - ESC to collapse back with animation

- Orchestrator now coordinates AST analysis with error parsing
- CacheManager tests using in-memory SQLite (5 tests)
- AST analyzer tests with temp C++ file parsing (2 tests)
- Orchestrator tests for graph construction (2 tests)

All 15 tests passing.

https://claude.ai/code/session_01Q1qaoCkmVRbj8aSJUksfVB