### PR TITLE
feat: Phase 2 — clangd + React Flow + cache + stack-trace graph

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@tauri-apps/api": "^2.1.1",
         "@tauri-apps/plugin-dialog": "^2.0.1",
         "@tauri-apps/plugin-fs": "^2.0.3",
+        "@xyflow/react": "^12.3.6",
         "monaco-editor": "^0.52.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -1524,6 +1525,55 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1545,7 +1595,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1580,6 +1630,38 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@xyflow/react": {
+      "version": "12.10.2",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.2.tgz",
+      "integrity": "sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.76",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.76",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.76.tgz",
+      "integrity": "sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
       }
     },
     "node_modules/baseline-browser-mapping": {
@@ -1650,6 +1732,12 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1661,8 +1749,113 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2092,6 +2285,15 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/vite": {
       "version": "6.4.2",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
@@ -2173,6 +2375,34 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "iter",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@tauri-apps/api": "^2.1.1",
     "@tauri-apps/plugin-dialog": "^2.0.1",
     "@tauri-apps/plugin-fs": "^2.0.3",
+    "@xyflow/react": "^12.3.6",
     "monaco-editor": "^0.52.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1576,7 +1576,7 @@ dependencies = [
 
 [[package]]
 name = "iter"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "lsp-types",
  "serde",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -678,6 +678,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "embed-resource"
 version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,6 +704,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,6 +724,16 @@ dependencies = [
  "serde",
  "serde_core",
  "typeid",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -753,6 +775,15 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "fluent-uri"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1547,6 +1578,7 @@ dependencies = [
 name = "iter"
 version = "0.1.0"
 dependencies = [
+ "lsp-types",
  "serde",
  "serde_json",
  "tauri",
@@ -1554,6 +1586,9 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "thiserror 2.0.18",
+ "tokio",
+ "url",
+ "which",
 ]
 
 [[package]]
@@ -1742,6 +1777,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1761,6 +1802,19 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lsp-types"
+version = "0.97.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53353550a17c04ac46c585feb189c2db82154fc84b79c7a66c96c2c644f66071"
+dependencies = [
+ "bitflags 1.3.2",
+ "fluent-uri",
+ "serde",
+ "serde_json",
+ "serde_repr",
+]
 
 [[package]]
 name = "mac"
@@ -2735,6 +2789,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3036,6 +3103,16 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -3691,9 +3768,23 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4327,6 +4418,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix",
+ "winsafe",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4784,6 +4887,12 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iter"
-version = "0.1.0"
+version = "0.2.0"
 description = "Iter — code relation visualizer"
 authors = ["LUDIARS"]
 edition = "2021"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,6 +20,10 @@ tauri-plugin-fs = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
+tokio = { version = "1", features = ["full"] }
+lsp-types = "0.97"
+url = "2"
+which = "7"
 
 [features]
 custom-protocol = ["tauri/custom-protocol"]

--- a/src-tauri/src/cache.rs
+++ b/src-tauri/src/cache.rs
@@ -1,0 +1,125 @@
+//! プロジェクト走査結果のディスクキャッシュ。
+//!
+//! - 保存先: `<config_dir>/iter/projects/<hash>.json`
+//!   - Windows: `%APPDATA%/iter/projects/`
+//!   - Linux:   `$XDG_CONFIG_HOME/iter/projects/` (既定 `~/.config/iter/projects/`)
+//!   - macOS:   `~/Library/Application Support/iter/projects/`
+//! - キー: project root の絶対パスを SHA-like (DefaultHasher) でハッシュ
+//! - 妥当性: cache 中の `root_mtime` と現在の root dir mtime を比較。一致なら fresh。
+//!
+//! `detect_project` 側からは `try_load` → ヒットなら即返す、無ければ通常走査して
+//! `save` する流れで使う。
+
+use serde::{Deserialize, Serialize};
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CachedProject<T: Serialize> {
+    pub root: String,
+    pub root_mtime_secs: u64,
+    pub cached_at_secs: u64,
+    pub version: u32,
+    pub project: T,
+}
+
+const CACHE_VERSION: u32 = 1;
+
+fn cache_dir() -> Option<PathBuf> {
+    dirs_like_config_dir().map(|d| d.join("iter").join("projects"))
+}
+
+/// `dirs` クレートを入れずに OS ごとの config dir を返す軽量実装。
+fn dirs_like_config_dir() -> Option<PathBuf> {
+    if cfg!(target_os = "windows") {
+        std::env::var_os("APPDATA").map(PathBuf::from)
+    } else if cfg!(target_os = "macos") {
+        std::env::var_os("HOME").map(|h| {
+            let mut p = PathBuf::from(h);
+            p.push("Library/Application Support");
+            p
+        })
+    } else {
+        // Linux 系: XDG_CONFIG_HOME → ~/.config
+        std::env::var_os("XDG_CONFIG_HOME")
+            .map(PathBuf::from)
+            .or_else(|| {
+                std::env::var_os("HOME").map(|h| {
+                    let mut p = PathBuf::from(h);
+                    p.push(".config");
+                    p
+                })
+            })
+    }
+}
+
+fn cache_path(root: &Path) -> Option<PathBuf> {
+    let dir = cache_dir()?;
+    let mut h = DefaultHasher::new();
+    root.to_string_lossy().to_lowercase().hash(&mut h);
+    Some(dir.join(format!("{:x}.json", h.finish())))
+}
+
+fn root_mtime_secs(root: &Path) -> u64 {
+    std::fs::metadata(root)
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|t| t.duration_since(SystemTime::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// fresh なキャッシュがあれば返す。なければ None。
+pub fn try_load<T>(root: &Path) -> Option<T>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    let path = cache_path(root)?;
+    let raw = std::fs::read(&path).ok()?;
+    // ジェネリック T を介すため一度 Value で読んで version + mtime を確認
+    let v: serde_json::Value = serde_json::from_slice(&raw).ok()?;
+    let version = v.get("version")?.as_u64()? as u32;
+    if version != CACHE_VERSION {
+        return None;
+    }
+    let cached_root_mtime = v.get("root_mtime_secs")?.as_u64()?;
+    if cached_root_mtime != root_mtime_secs(root) {
+        return None; // root の更新時刻が変わっていればキャッシュは古い
+    }
+    let project_json = v.get("project")?.clone();
+    serde_json::from_value::<T>(project_json).ok()
+}
+
+/// project を保存。失敗しても致命ではないので Result は string で返す。
+pub fn save<T: Serialize>(root: &Path, project: &T) -> Result<(), String> {
+    let path = cache_path(root).ok_or("cache dir 不明")?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("mkdir: {e}"))?;
+    }
+    let payload = CachedProject {
+        root: root.to_string_lossy().into_owned(),
+        root_mtime_secs: root_mtime_secs(root),
+        cached_at_secs: now_secs(),
+        version: CACHE_VERSION,
+        project,
+    };
+    let body = serde_json::to_vec_pretty(&payload).map_err(|e| format!("serialize: {e}"))?;
+    std::fs::write(&path, body).map_err(|e| format!("write: {e}"))?;
+    Ok(())
+}
+
+/// キャッシュを明示破棄 (`refresh_project` 等から)。
+pub fn invalidate(root: &Path) {
+    if let Some(p) = cache_path(root) {
+        let _ = std::fs::remove_file(p);
+    }
+}

--- a/src-tauri/src/compile_db.rs
+++ b/src-tauri/src/compile_db.rs
@@ -1,0 +1,76 @@
+//! `compile_commands.json` の検知 / 自動生成。
+//!
+//! 検知ルール (優先順):
+//!   1. `<root>/compile_commands.json`
+//!   2. `<root>/build/compile_commands.json`
+//!   3. `<root>/build*/compile_commands.json` のいずれか (`out/`, `cmake-build-debug/` 等)
+//!
+//! どこにもない場合は **CMake を呼び出して** `build/` に生成する。
+//! `cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON <root>` を実行するだけ。
+//! 失敗時はエラーを返してフロントに伝える。
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// compile_commands.json の場所を確定する。なければ生成する。
+pub fn ensure_compile_commands(root: &Path) -> Result<PathBuf, String> {
+    if let Some(p) = find_existing(root) {
+        return Ok(p);
+    }
+    if !root.join("CMakeLists.txt").exists() {
+        return Err(
+            "CMakeLists.txt が無いため compile_commands.json を自動生成できません".to_string(),
+        );
+    }
+    generate_via_cmake(root)
+}
+
+fn find_existing(root: &Path) -> Option<PathBuf> {
+    let direct = root.join("compile_commands.json");
+    if direct.exists() {
+        return Some(direct);
+    }
+    // build*/compile_commands.json を浅く探す (深さ 1)
+    for entry in std::fs::read_dir(root).ok()?.flatten() {
+        let p = entry.path();
+        if p.is_dir() {
+            let cand = p.join("compile_commands.json");
+            if cand.exists() {
+                return Some(cand);
+            }
+        }
+    }
+    None
+}
+
+fn generate_via_cmake(root: &Path) -> Result<PathBuf, String> {
+    let build_dir = root.join("build");
+    std::fs::create_dir_all(&build_dir).map_err(|e| format!("build dir 作成失敗: {e}"))?;
+
+    let cmake = which::which("cmake").map_err(|_| {
+        "cmake コマンドが PATH に見つかりません (CMake をインストールするか、既存の compile_commands.json を root か build/ に置いてください)".to_string()
+    })?;
+
+    let output = Command::new(cmake)
+        .arg("-B")
+        .arg(&build_dir)
+        .arg("-S")
+        .arg(root)
+        .arg("-DCMAKE_EXPORT_COMPILE_COMMANDS=ON")
+        .output()
+        .map_err(|e| format!("cmake 起動失敗: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("cmake 失敗 (exit {}): {}", output.status, stderr));
+    }
+
+    let cc = build_dir.join("compile_commands.json");
+    if !cc.exists() {
+        return Err(format!(
+            "cmake は完了したが {} が生成されませんでした",
+            cc.display()
+        ));
+    }
+    Ok(cc)
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,18 +1,33 @@
+mod cache;
+mod compile_db;
+mod lsp;
+mod lsp_commands;
 mod project;
+mod stack_trace;
 mod window;
+
+use lsp_commands::LspState;
 
 /// Tauri 2 entrypoint.
 ///
-/// Plugins (`dialog`, `fs`) を有効化してから、フロントエンドが呼ぶ
-/// `#[tauri::command]` を `invoke_handler` に登録する。
+/// Plugins (`dialog`, `fs`) を有効化、LSP 用 state (clangd ハンドル) を `manage`
+/// で抱え、フロントエンドが叩く `#[tauri::command]` 群を `invoke_handler` に登録。
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
+        .manage(LspState::default())
         .invoke_handler(tauri::generate_handler![
             project::detect_project,
+            project::refresh_project,
             window::open_file_window,
+            window::open_at,
+            lsp_commands::lsp_open_project,
+            lsp_commands::lsp_open_file,
+            lsp_commands::lsp_call_hierarchy,
+            lsp_commands::lsp_references,
+            stack_trace::parse_stack_trace,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod compile_db;
 mod lsp;
 mod lsp_commands;
 mod project;
+mod snippet;
 mod stack_trace;
 mod window;
 
@@ -23,11 +24,13 @@ pub fn run() {
             project::refresh_project,
             window::open_file_window,
             window::open_at,
+            window::close_other_windows,
             lsp_commands::lsp_open_project,
             lsp_commands::lsp_open_file,
             lsp_commands::lsp_call_hierarchy,
             lsp_commands::lsp_references,
             stack_trace::parse_stack_trace,
+            snippet::read_snippet,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/lsp.rs
+++ b/src-tauri/src/lsp.rs
@@ -1,0 +1,309 @@
+//! clangd subprocess + LSP JSON-RPC ブリッジ。
+//!
+//! - stdin/stdout で JSON-RPC、Content-Length ヘッダフレーミング
+//! - 1 プロジェクト = 1 clangd プロセス、`AppState` 配下に Arc<Mutex<Option<Client>>> で保持
+//! - フロントが叩く Tauri コマンドからは `Client::*` を await で呼ぶ
+//!
+//! Phase 2 の MVP では call hierarchy / references / definition の 3 系統だけ。
+//! semanticTokens / inlayHint / formatter 等は今回スコープ外。
+
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicI64, Ordering};
+
+use lsp_types::{
+    CallHierarchyIncomingCall, CallHierarchyItem, CallHierarchyOutgoingCall, ClientCapabilities,
+    DidOpenTextDocumentParams, InitializeParams, InitializedParams, Location, Position,
+    ReferenceContext, ReferenceParams, TextDocumentIdentifier, TextDocumentItem,
+    TextDocumentPositionParams, Uri, WorkDoneProgressParams, WorkspaceFolder,
+};
+use std::str::FromStr;
+use serde_json::{Value, json};
+use std::collections::HashMap;
+use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, Command};
+use tokio::sync::{Mutex, oneshot};
+
+#[derive(Debug, thiserror::Error)]
+pub enum LspError {
+    #[error("clangd not found in PATH")]
+    ClangdNotFound,
+    #[error("io: {0}")]
+    Io(String),
+    #[error("rpc: {0}")]
+    Rpc(String),
+}
+
+impl From<std::io::Error> for LspError {
+    fn from(e: std::io::Error) -> Self {
+        LspError::Io(e.to_string())
+    }
+}
+
+type Pending = Arc<Mutex<HashMap<i64, oneshot::Sender<Result<Value, String>>>>>;
+
+pub struct ClangdClient {
+    _process: Child,
+    stdin: Mutex<ChildStdin>,
+    next_id: AtomicI64,
+    pending: Pending,
+}
+
+impl ClangdClient {
+    /// clangd を起動し、initialize / initialized を完了するまでブロックする。
+    pub async fn spawn(project_root: &Path, compile_commands_dir: &Path) -> Result<Self, LspError> {
+        let clangd = which::which("clangd").map_err(|_| LspError::ClangdNotFound)?;
+
+        let mut child = Command::new(clangd)
+            .arg(format!(
+                "--compile-commands-dir={}",
+                compile_commands_dir.display()
+            ))
+            .arg("--background-index")
+            .arg("--clang-tidy=false")
+            .arg("--header-insertion=never")
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .spawn()?;
+
+        let stdin = child.stdin.take().expect("stdin captured");
+        let stdout = child.stdout.take().expect("stdout captured");
+
+        let pending: Pending = Arc::new(Mutex::new(HashMap::new()));
+        let pending_for_reader = pending.clone();
+
+        // stdout reader タスク: 受信 → pending の oneshot へ流す
+        tokio::spawn(async move {
+            let mut reader = BufReader::new(stdout);
+            loop {
+                match read_message(&mut reader).await {
+                    Ok(Some(value)) => {
+                        if let Some(id) = value.get("id").and_then(|v| v.as_i64()) {
+                            let mut p = pending_for_reader.lock().await;
+                            if let Some(tx) = p.remove(&id) {
+                                if let Some(err) = value.get("error") {
+                                    let _ = tx.send(Err(err.to_string()));
+                                } else {
+                                    let result =
+                                        value.get("result").cloned().unwrap_or(Value::Null);
+                                    let _ = tx.send(Ok(result));
+                                }
+                            }
+                        }
+                        // notification (id 無し) は今回無視
+                    }
+                    Ok(None) => break,
+                    Err(_) => break,
+                }
+            }
+        });
+
+        let client = Self {
+            _process: child,
+            stdin: Mutex::new(stdin),
+            next_id: AtomicI64::new(1),
+            pending,
+        };
+
+        client.initialize(project_root).await?;
+        client.initialized().await?;
+        Ok(client)
+    }
+
+    async fn initialize(&self, project_root: &Path) -> Result<(), LspError> {
+        let url = url::Url::from_directory_path(project_root)
+            .map_err(|_| LspError::Rpc("invalid project_root path".to_string()))?;
+        let root_uri = Uri::from_str(url.as_str())
+            .map_err(|e| LspError::Rpc(format!("uri parse: {e}")))?;
+        #[allow(deprecated)]
+        let params = InitializeParams {
+            process_id: Some(std::process::id()),
+            root_path: None,
+            root_uri: Some(root_uri.clone()),
+            initialization_options: None,
+            capabilities: ClientCapabilities::default(),
+            trace: None,
+            workspace_folders: Some(vec![WorkspaceFolder {
+                uri: root_uri,
+                name: project_root
+                    .file_name()
+                    .map(|s| s.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| "root".to_string()),
+            }]),
+            client_info: None,
+            locale: None,
+            work_done_progress_params: WorkDoneProgressParams::default(),
+        };
+        let _ = self
+            .request("initialize", serde_json::to_value(params).unwrap())
+            .await?;
+        Ok(())
+    }
+
+    async fn initialized(&self) -> Result<(), LspError> {
+        let params = InitializedParams {};
+        self.notify("initialized", serde_json::to_value(params).unwrap())
+            .await
+    }
+
+    pub async fn did_open(
+        &self,
+        uri: Uri,
+        language_id: &str,
+        text: String,
+    ) -> Result<(), LspError> {
+        let params = DidOpenTextDocumentParams {
+            text_document: TextDocumentItem {
+                uri,
+                language_id: language_id.to_string(),
+                version: 1,
+                text,
+            },
+        };
+        self.notify("textDocument/didOpen", serde_json::to_value(params).unwrap())
+            .await
+    }
+
+    pub async fn prepare_call_hierarchy(
+        &self,
+        uri: Uri,
+        position: Position,
+    ) -> Result<Vec<CallHierarchyItem>, LspError> {
+        let params = TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier { uri },
+            position,
+        };
+        let v = self
+            .request(
+                "textDocument/prepareCallHierarchy",
+                serde_json::to_value(params).unwrap(),
+            )
+            .await?;
+        Ok(serde_json::from_value(v).unwrap_or_default())
+    }
+
+    pub async fn incoming_calls(
+        &self,
+        item: CallHierarchyItem,
+    ) -> Result<Vec<CallHierarchyIncomingCall>, LspError> {
+        let v = self
+            .request("callHierarchy/incomingCalls", json!({ "item": item }))
+            .await?;
+        Ok(serde_json::from_value(v).unwrap_or_default())
+    }
+
+    pub async fn outgoing_calls(
+        &self,
+        item: CallHierarchyItem,
+    ) -> Result<Vec<CallHierarchyOutgoingCall>, LspError> {
+        let v = self
+            .request("callHierarchy/outgoingCalls", json!({ "item": item }))
+            .await?;
+        Ok(serde_json::from_value(v).unwrap_or_default())
+    }
+
+    pub async fn references(
+        &self,
+        uri: Uri,
+        position: Position,
+    ) -> Result<Vec<Location>, LspError> {
+        let params = ReferenceParams {
+            text_document_position: TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier { uri },
+                position,
+            },
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: Default::default(),
+            context: ReferenceContext {
+                include_declaration: false,
+            },
+        };
+        let v = self
+            .request("textDocument/references", serde_json::to_value(params).unwrap())
+            .await?;
+        Ok(serde_json::from_value(v).unwrap_or_default())
+    }
+
+    async fn request(&self, method: &str, params: Value) -> Result<Value, LspError> {
+        let id = self.next_id.fetch_add(1, Ordering::SeqCst);
+        let (tx, rx) = oneshot::channel();
+        self.pending.lock().await.insert(id, tx);
+
+        let msg = json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        });
+        self.send_raw(&msg).await?;
+
+        match rx.await {
+            Ok(Ok(v)) => Ok(v),
+            Ok(Err(e)) => Err(LspError::Rpc(e)),
+            Err(_) => Err(LspError::Rpc("response channel closed".to_string())),
+        }
+    }
+
+    async fn notify(&self, method: &str, params: Value) -> Result<(), LspError> {
+        let msg = json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+        });
+        self.send_raw(&msg).await
+    }
+
+    async fn send_raw(&self, msg: &Value) -> Result<(), LspError> {
+        let body = serde_json::to_vec(msg).map_err(|e| LspError::Rpc(e.to_string()))?;
+        let header = format!("Content-Length: {}\r\n\r\n", body.len());
+        let mut stdin = self.stdin.lock().await;
+        stdin.write_all(header.as_bytes()).await?;
+        stdin.write_all(&body).await?;
+        stdin.flush().await?;
+        Ok(())
+    }
+}
+
+/// Content-Length フレーム 1 件を読む。EOF なら Ok(None)。
+async fn read_message<R: AsyncReadExt + Unpin>(
+    reader: &mut R,
+) -> Result<Option<Value>, std::io::Error> {
+    // 1) ヘッダ部分を読む。Content-Length: <n>\r\n のあと \r\n で本体に入る。
+    let mut header = Vec::new();
+    let mut prev = 0u8;
+    let mut prev2 = 0u8;
+    let mut prev3 = 0u8;
+    loop {
+        let mut byte = [0u8; 1];
+        let n = reader.read(&mut byte).await?;
+        if n == 0 {
+            return Ok(None);
+        }
+        header.push(byte[0]);
+        // \r\n\r\n を検出
+        if prev3 == b'\r' && prev2 == b'\n' && prev == b'\r' && byte[0] == b'\n' {
+            break;
+        }
+        prev3 = prev2;
+        prev2 = prev;
+        prev = byte[0];
+    }
+
+    let header_str = String::from_utf8_lossy(&header);
+    let mut content_length: usize = 0;
+    for line in header_str.split("\r\n") {
+        if let Some(rest) = line.strip_prefix("Content-Length:") {
+            content_length = rest.trim().parse().unwrap_or(0);
+        }
+    }
+    if content_length == 0 {
+        return Ok(None);
+    }
+
+    let mut body = vec![0u8; content_length];
+    reader.read_exact(&mut body).await?;
+    let v = serde_json::from_slice::<Value>(&body)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    Ok(Some(v))
+}

--- a/src-tauri/src/lsp_commands.rs
+++ b/src-tauri/src/lsp_commands.rs
@@ -1,0 +1,146 @@
+//! Tauri が呼び出す `#[command]` エンドポイント群。
+//!
+//! state として `Mutex<Option<ClangdClient>>` を 1 つだけ持ち、`detect_project`
+//! 直後に `lsp_open_project` を呼ぶ想定。フロントは `lsp_call_hierarchy` /
+//! `lsp_definitions` / `lsp_references` で 1 ヶ所のシンボル情報を取れる。
+//!
+//! Phase 2 MVP では同時に 1 プロジェクトしか開けない (シングルトン)。
+
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use lsp_types::{
+    CallHierarchyIncomingCall, CallHierarchyItem, CallHierarchyOutgoingCall, Location, Uri,
+};
+use serde::Serialize;
+use tokio::sync::Mutex;
+
+use crate::compile_db;
+use crate::lsp::ClangdClient;
+
+#[derive(Default)]
+pub struct LspState {
+    pub client: Mutex<Option<Arc<ClangdClient>>>,
+    pub project_root: Mutex<Option<PathBuf>>,
+}
+
+/// プロジェクトを開いて clangd を起動する。compile_commands.json を必要なら生成。
+#[tauri::command]
+pub async fn lsp_open_project(
+    state: tauri::State<'_, LspState>,
+    root: String,
+) -> Result<(), String> {
+    let root_path = PathBuf::from(&root);
+    let cc = compile_db::ensure_compile_commands(&root_path)?;
+    let cc_dir = cc.parent().map(PathBuf::from).unwrap_or(root_path.clone());
+
+    let client = ClangdClient::spawn(&root_path, &cc_dir)
+        .await
+        .map_err(|e| e.to_string())?;
+    let arc = Arc::new(client);
+
+    *state.client.lock().await = Some(arc);
+    *state.project_root.lock().await = Some(root_path);
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn lsp_open_file(
+    state: tauri::State<'_, LspState>,
+    path: String,
+    text: String,
+) -> Result<(), String> {
+    let client = require_client(&state).await?;
+    let uri = path_to_uri(&path)?;
+    let language_id = guess_language_id(&path);
+    client
+        .did_open(uri, &language_id, text)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[derive(Serialize)]
+pub struct CallHierarchyResult {
+    pub items: Vec<CallHierarchyItem>,
+    pub incoming: Vec<CallHierarchyIncomingCall>,
+    pub outgoing: Vec<CallHierarchyOutgoingCall>,
+}
+
+/// 指定位置で prepareCallHierarchy → incoming/outgoing を 1 まとめで取得。
+#[tauri::command]
+pub async fn lsp_call_hierarchy(
+    state: tauri::State<'_, LspState>,
+    path: String,
+    line: u32,
+    character: u32,
+) -> Result<CallHierarchyResult, String> {
+    let client = require_client(&state).await?;
+    let uri = path_to_uri(&path)?;
+    let pos = lsp_types::Position { line, character };
+
+    let items = client
+        .prepare_call_hierarchy(uri, pos)
+        .await
+        .map_err(|e| e.to_string())?;
+    let mut incoming = Vec::new();
+    let mut outgoing = Vec::new();
+    for it in &items {
+        if let Ok(mut v) = client.incoming_calls(it.clone()).await {
+            incoming.append(&mut v);
+        }
+        if let Ok(mut v) = client.outgoing_calls(it.clone()).await {
+            outgoing.append(&mut v);
+        }
+    }
+    Ok(CallHierarchyResult {
+        items,
+        incoming,
+        outgoing,
+    })
+}
+
+#[tauri::command]
+pub async fn lsp_references(
+    state: tauri::State<'_, LspState>,
+    path: String,
+    line: u32,
+    character: u32,
+) -> Result<Vec<Location>, String> {
+    let client = require_client(&state).await?;
+    let uri = path_to_uri(&path)?;
+    client
+        .references(uri, lsp_types::Position { line, character })
+        .await
+        .map_err(|e| e.to_string())
+}
+
+fn path_to_uri(path: &str) -> Result<Uri, String> {
+    let url = url::Url::from_file_path(path).map_err(|_| format!("invalid path: {path}"))?;
+    Uri::from_str(url.as_str()).map_err(|e| format!("uri parse: {e}"))
+}
+
+async fn require_client(
+    state: &tauri::State<'_, LspState>,
+) -> Result<Arc<ClangdClient>, String> {
+    let guard = state.client.lock().await;
+    guard
+        .clone()
+        .ok_or_else(|| "LSP not initialized — call lsp_open_project first".to_string())
+}
+
+fn guess_language_id(path: &str) -> String {
+    let lower = path.to_lowercase();
+    if lower.ends_with(".c") || lower.ends_with(".h") {
+        "c".to_string()
+    } else if lower.ends_with(".cpp")
+        || lower.ends_with(".cc")
+        || lower.ends_with(".cxx")
+        || lower.ends_with(".hpp")
+        || lower.ends_with(".hxx")
+    {
+        "cpp".to_string()
+    } else {
+        "plaintext".to_string()
+    }
+}

--- a/src-tauri/src/project.rs
+++ b/src-tauri/src/project.rs
@@ -1,12 +1,16 @@
 //! プロジェクト検知 + ファイルツリー列挙。
 //!
-//! MVP では指定ディレクトリ直下〜数階層を走査し、CMakeLists.txt または
-//! `*.vcxproj` の有無で build_system を判定する。compile_commands.json の
-//! 自動生成は Phase 2 (clangd 統合と一緒に入れる)。
+//! - 指定ディレクトリ直下〜数階層を走査して CMakeLists.txt / `*.vcxproj` の
+//!   有無で build_system を判定する。
+//! - 結果はディスクキャッシュに保存し、次回は root mtime 一致で即返す
+//!   (`refresh_project` で明示破棄可能)。
+//! - compile_commands.json の自動生成は `lsp_open_project` 側で行う。
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use thiserror::Error;
+
+use crate::cache;
 
 #[derive(Debug, Error, Serialize)]
 pub enum ProjectError {
@@ -24,7 +28,7 @@ impl From<std::io::Error> for ProjectError {
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum BuildSystem {
     Cmake,
@@ -32,14 +36,17 @@ pub enum BuildSystem {
     Unknown,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ProjectInfo {
     pub root: String,
     pub build_system: BuildSystem,
     pub files: Vec<FileNode>,
+    /// このプロジェクトの結果がキャッシュからきたかどうか (フロント表示用)
+    #[serde(default)]
+    pub from_cache: bool,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct FileNode {
     pub path: String,
     pub rel: String,
@@ -48,10 +55,6 @@ pub struct FileNode {
     pub children: Vec<FileNode>,
 }
 
-/// MVP の走査ルール:
-/// - 隠しディレクトリ (`.git` 等) は除外
-/// - `node_modules`, `target`, `build`, `dist`, `.cache` 等のビルド成果物も除外
-/// - 深さ制限 8 (現実的な C++ プロジェクトを覆える)
 const SKIP_DIR_NAMES: &[&str] = &[
     "node_modules",
     "target",
@@ -76,13 +79,39 @@ pub fn detect_project(root: String) -> Result<ProjectInfo, ProjectError> {
         return Err(ProjectError::NotADirectory(root));
     }
 
-    let build_system = detect_build_system(&root_path);
-    let files = walk(&root_path, &root_path, 0)?;
+    // キャッシュヒット (root mtime 一致) なら即返す
+    if let Some(mut cached) = cache::try_load::<ProjectInfo>(&root_path) {
+        cached.from_cache = true;
+        return Ok(cached);
+    }
 
+    let info = walk_root(&root_path)?;
+    // キャッシュ保存に失敗しても致命ではない (権限不足など) — 続行
+    let _ = cache::save(&root_path, &info);
+    Ok(info)
+}
+
+/// 明示再走査 (キャッシュを破棄してから走査)。
+#[tauri::command]
+pub fn refresh_project(root: String) -> Result<ProjectInfo, ProjectError> {
+    let root_path = PathBuf::from(&root);
+    if !root_path.exists() {
+        return Err(ProjectError::NotFound(root));
+    }
+    cache::invalidate(&root_path);
+    let info = walk_root(&root_path)?;
+    let _ = cache::save(&root_path, &info);
+    Ok(info)
+}
+
+fn walk_root(root_path: &Path) -> Result<ProjectInfo, ProjectError> {
+    let build_system = detect_build_system(root_path);
+    let files = walk(root_path, root_path, 0)?;
     Ok(ProjectInfo {
         root: root_path.to_string_lossy().into_owned(),
         build_system,
         files,
+        from_cache: false,
     })
 }
 
@@ -90,7 +119,6 @@ fn detect_build_system(root: &Path) -> BuildSystem {
     if root.join("CMakeLists.txt").exists() {
         return BuildSystem::Cmake;
     }
-    // *.vcxproj が直下にあるか軽く見る (再帰探索はしない、速度優先)
     if let Ok(entries) = std::fs::read_dir(root) {
         for e in entries.flatten() {
             let p = e.path();
@@ -123,7 +151,6 @@ fn walk(base: &Path, dir: &Path, depth: usize) -> Result<Vec<FileNode>, ProjectE
             !SKIP_DIR_NAMES.iter().any(|skip| s.eq_ignore_ascii_case(skip))
         })
         .collect();
-    // ディレクトリ → ファイル の順、それぞれ名前 ASCII でソート
     entries.sort_by_key(|e| {
         (
             !e.file_type().map(|t| t.is_dir()).unwrap_or(false),

--- a/src-tauri/src/snippet.rs
+++ b/src-tauri/src/snippet.rs
@@ -1,0 +1,33 @@
+//! ファイルの一部行 (target ± context) を返す軽量コマンド。
+//!
+//! 関連グラフのカードに表示するスニペットを取りに行く。
+//! `read_snippet(path, line=42, context=5)` だと 37〜47 行を返す。
+//! Monaco を起動せず、軽量に多数のカードを描画するための API。
+
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct Snippet {
+    /// 0-based の最初の行番号
+    pub start_line: u32,
+    /// クエリされた行 (0-based)
+    pub target_line: u32,
+    pub lines: Vec<String>,
+}
+
+#[tauri::command]
+pub fn read_snippet(path: String, line: u32, context: u32) -> Result<Snippet, String> {
+    let text = std::fs::read_to_string(&path).map_err(|e| format!("read: {e}"))?;
+    let all: Vec<&str> = text.split('\n').collect();
+    let total = all.len();
+    let target = line as usize;
+    let ctx = context as usize;
+    let start = target.saturating_sub(ctx);
+    let end = (target + ctx + 1).min(total);
+    let lines = all[start..end].iter().map(|s| s.to_string()).collect();
+    Ok(Snippet {
+        start_line: start as u32,
+        target_line: target as u32,
+        lines,
+    })
+}

--- a/src-tauri/src/stack_trace.rs
+++ b/src-tauri/src/stack_trace.rs
@@ -1,0 +1,161 @@
+//! スタックトレース文字列を frame 配列に分解する。
+//!
+//! 対応する書式 (best-effort、複数を 1 入力で混ぜても OK):
+//!   - GCC/Clang sanitizer: `    #0 0x... in func /path/file.cpp:LINE:COL`
+//!   - GDB:                 `#0  func (args) at /path/file.cpp:LINE`
+//!   - V8 / Node:           `    at func (/path/file.js:LINE:COL)`
+//!   - Python:              `  File "/path/file.py", line LINE, in func`
+//!   - Rust panic:          `   N: func\n             at /path/file.rs:LINE:COL`
+//!
+//! 各 frame は (path, line, function?) を抽出し、project_root に含まれるかで
+//! `in_project` を立てる。project_root が None のときは全部 false。
+
+use serde::Serialize;
+use std::path::Path;
+
+#[derive(Debug, Serialize)]
+pub struct Frame {
+    pub index: usize,
+    pub function: Option<String>,
+    pub path: String,
+    pub line: u32,
+    pub column: Option<u32>,
+    pub in_project: bool,
+}
+
+#[tauri::command]
+pub fn parse_stack_trace(text: String, project_root: Option<String>) -> Vec<Frame> {
+    let root = project_root.as_deref().map(Path::new);
+    let mut frames = Vec::new();
+
+    for line in text.lines() {
+        if let Some(f) = try_parse(line) {
+            let in_project = match root {
+                Some(r) => Path::new(&f.0).starts_with(r),
+                None => false,
+            };
+            frames.push(Frame {
+                index: frames.len(),
+                function: f.3,
+                path: f.0,
+                line: f.1,
+                column: f.2,
+                in_project,
+            });
+        }
+    }
+    frames
+}
+
+/// (path, line, col?, function?) を返す。マッチしなければ None。
+fn try_parse(line: &str) -> Option<(String, u32, Option<u32>, Option<String>)> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    // V8 / Node: `at func (/path:LINE:COL)`  または  `at /path:LINE:COL`
+    if let Some(rest) = trimmed.strip_prefix("at ") {
+        if let Some((func, paren)) = rest.split_once(" (") {
+            if let Some(loc) = paren.strip_suffix(')') {
+                if let Some((p, l, c)) = parse_path_line_col(loc) {
+                    return Some((p, l, c, Some(func.to_string())));
+                }
+            }
+        }
+        if let Some((p, l, c)) = parse_path_line_col(rest) {
+            return Some((p, l, c, None));
+        }
+    }
+
+    // Python:  File "/path", line N, in func
+    if let Some(rest) = trimmed.strip_prefix("File \"") {
+        if let Some(close) = rest.find('"') {
+            let p = &rest[..close];
+            // ", line N, in func"
+            let after = &rest[close..];
+            if let Some(idx) = after.find("line ") {
+                let after = &after[idx + 5..];
+                let line_str: String = after.chars().take_while(|c| c.is_ascii_digit()).collect();
+                let line_n: u32 = line_str.parse().ok()?;
+                let func = after
+                    .find("in ")
+                    .map(|i| after[i + 3..].trim().to_string())
+                    .filter(|s| !s.is_empty());
+                return Some((p.to_string(), line_n, None, func));
+            }
+        }
+    }
+
+    // GCC/Clang sanitizer:  #N 0x... in func /path/file.cpp:LINE[:COL]
+    if let Some(rest) = trimmed.strip_prefix('#') {
+        // skip "<n> 0x... "
+        let parts: Vec<&str> = rest.splitn(4, ' ').collect();
+        if parts.len() >= 4 && parts[2] == "in" {
+            let tail = parts[3]; // "func /path:LINE[:COL]"
+            if let Some(sp) = tail.find(' ') {
+                let func = tail[..sp].to_string();
+                let loc = &tail[sp + 1..];
+                if let Some((p, l, c)) = parse_path_line_col(loc) {
+                    return Some((p, l, c, Some(func)));
+                }
+            }
+        }
+    }
+
+    // GDB:  #N  func (args) at /path:LINE
+    if let Some(rest) = trimmed.strip_prefix('#') {
+        if let Some(idx) = rest.find(" at ") {
+            let after_at = &rest[idx + 4..];
+            if let Some((p, l, c)) = parse_path_line_col(after_at) {
+                let func = rest[..idx]
+                    .splitn(2, ' ')
+                    .nth(1)
+                    .map(|s| s.trim().split_whitespace().next().unwrap_or("").to_string())
+                    .filter(|s| !s.is_empty());
+                return Some((p, l, c, func));
+            }
+        }
+    }
+
+    // Rust panic style:  "             at /path:LINE:COL"
+    if let Some(rest) = trimmed.strip_prefix("at ") {
+        if let Some((p, l, c)) = parse_path_line_col(rest) {
+            return Some((p, l, c, None));
+        }
+    }
+
+    None
+}
+
+/// `path:line[:col]` を分解。Windows のドライブレター (`C:`) を想定して、
+/// **末尾から** コロンを探す。
+fn parse_path_line_col(s: &str) -> Option<(String, u32, Option<u32>)> {
+    let s = s.trim();
+    let mut parts: Vec<&str> = s.rsplitn(3, ':').collect();
+    parts.reverse();
+    match parts.len() {
+        2 => {
+            let line: u32 = parts[1].trim().parse().ok()?;
+            Some((parts[0].to_string(), line, None))
+        }
+        3 => {
+            // 3 分割の最初がドライブレター 1 文字なら path に戻す (Windows 対応)
+            if parts[0].len() == 1
+                && parts[0]
+                    .chars()
+                    .next()
+                    .map(|c| c.is_ascii_alphabetic())
+                    .unwrap_or(false)
+            {
+                let line: u32 = parts[2].trim().parse().ok()?;
+                let path = format!("{}:{}", parts[0], parts[1]);
+                Some((path, line, None))
+            } else {
+                let line: u32 = parts[1].trim().parse().ok()?;
+                let col: Option<u32> = parts[2].trim().parse().ok();
+                Some((parts[0].to_string(), line, col))
+            }
+        }
+        _ => None,
+    }
+}

--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -105,6 +105,25 @@ fn label_for(path: &str) -> String {
     format!("file-{:x}", h.finish())
 }
 
+/// 指定 label 以外の `file-*` ラベルを持つウィンドウを全て閉じる。
+/// Control Panel (`control-panel`) は対象外。
+#[tauri::command]
+pub async fn close_other_windows(app: AppHandle, except_label: String) -> Result<u32, String> {
+    let windows = app.webview_windows();
+    let mut closed = 0u32;
+    for (label, w) in windows.iter() {
+        if label == &except_label {
+            continue;
+        }
+        if !label.starts_with("file-") {
+            continue;
+        }
+        let _ = w.close();
+        closed += 1;
+    }
+    Ok(closed)
+}
+
 fn encode_query(s: &str) -> String {
     // `URLSearchParams` 互換のシンプルな %-encode (空白は %20)
     let mut out = String::with_capacity(s.len());

--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -2,32 +2,93 @@
 //!
 //! 1 ファイル = 1 OS ウインドウ。`label` を `file-<hash>` で安定化させて、
 //! 既に開いていれば前面に出すだけ。新規なら `WebviewWindowBuilder` で生成。
+//!
+//! `open_at` は `path + line + col` を受け取って、対応ウィンドウを (新規 or 再利用)
+//! 開きつつ、フロントへ位置情報を eve で投げる。フロント側は監聴し、
+//! Monaco を該当行へ scroll + (オプションで) 宣言追跡をかける。
 
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
-use tauri::{AppHandle, Manager, WebviewUrl, WebviewWindowBuilder};
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
+
+#[derive(Debug, Clone, Serialize)]
+struct OpenAtPayload {
+    path: String,
+    line: u32,
+    column: u32,
+    follow_definition: bool,
+}
 
 #[tauri::command]
 pub async fn open_file_window(app: AppHandle, path: String) -> Result<(), String> {
-    let label = label_for(&path);
+    open_internal(&app, &path, None, None, false).await
+}
 
+/// `path + line + (column?)` で開く。`follow_definition=true` なら、
+/// フロントが Monaco mount 後に LSP の textDocument/definition を呼んで、
+/// 結果が現在ファイル外を指していたらさらにそちらを `open_at` する。
+#[tauri::command]
+pub async fn open_at(
+    app: AppHandle,
+    path: String,
+    line: u32,
+    column: Option<u32>,
+    follow_definition: Option<bool>,
+) -> Result<(), String> {
+    open_internal(
+        &app,
+        &path,
+        Some(line),
+        column,
+        follow_definition.unwrap_or(false),
+    )
+    .await
+}
+
+async fn open_internal(
+    app: &AppHandle,
+    path: &str,
+    line: Option<u32>,
+    column: Option<u32>,
+    follow_definition: bool,
+) -> Result<(), String> {
+    let label = label_for(path);
+
+    // 既開ウィンドウなら前面 + イベント送信のみ
     if let Some(existing) = app.get_webview_window(&label) {
         let _ = existing.set_focus();
+        if let Some(l) = line {
+            let payload = OpenAtPayload {
+                path: path.to_string(),
+                line: l,
+                column: column.unwrap_or(0),
+                follow_definition,
+            };
+            let _ = existing.emit("iter://open-at", &payload);
+        }
         return Ok(());
     }
 
-    // path はクエリで file-window.html に渡す。WebviewUrl::App は frontendDist
-    // 配下からの相対パス (+ クエリ) を受け取る。
-    let webview_url = WebviewUrl::App(
-        format!("file-window.html?path={}", encode_query(&path)).into(),
-    );
+    // 新規ウィンドウ。クエリ経由で path/line/col/follow を投げる。
+    let mut query = format!("path={}", encode_query(path));
+    if let Some(l) = line {
+        query.push_str(&format!("&line={}", l));
+    }
+    if let Some(c) = column {
+        query.push_str(&format!("&col={}", c));
+    }
+    if follow_definition {
+        query.push_str("&follow=1");
+    }
+    let webview_url = WebviewUrl::App(format!("file-window.html?{}", query).into());
 
-    let title = std::path::Path::new(&path)
+    let title = std::path::Path::new(path)
         .file_name()
         .map(|s| format!("Iter — {}", s.to_string_lossy()))
         .unwrap_or_else(|| format!("Iter — {}", path));
 
-    WebviewWindowBuilder::new(&app, label, webview_url)
+    WebviewWindowBuilder::new(app, label, webview_url)
         .title(title)
         .inner_size(1100.0, 780.0)
         .min_inner_size(640.0, 400.0)

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Iter",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "identifier": "org.ludiars.iter",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/ControlPanel.tsx
+++ b/src/ControlPanel.tsx
@@ -1,13 +1,18 @@
 import { useCallback, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-dialog";
+import { emit } from "@tauri-apps/api/event";
+import { lsp, win, type StackFrame } from "./lsp";
+import { StackTraceGraph } from "./StackTraceGraph";
 
-/** Rust 側 `detect_project` が返す形。`tauri/src/project.rs` と同期 */
 interface ProjectInfo {
   root: string;
   build_system: "cmake" | "vcxproj" | "unknown";
   files: FileNode[];
+  from_cache?: boolean;
 }
+
+const PROJECT_ROOT_KEY = "iter:project_root";
 
 interface FileNode {
   path: string;
@@ -17,21 +22,26 @@ interface FileNode {
   children: FileNode[];
 }
 
-/** Phase 2 で graph に表示する関連の種類 (UI だけ先に置く) */
 const RELATION_KINDS = [
   { key: "callers", label: "呼び出し元 (callers)" },
   { key: "callees", label: "呼び出し先 (callees)" },
   { key: "references", label: "参照 (references)" },
-  { key: "definitions", label: "定義先 (definitions)" },
 ] as const;
 
 export function ControlPanel() {
   const [project, setProject] = useState<ProjectInfo | null>(null);
   const [loading, setLoading] = useState(false);
+  const [lspState, setLspState] = useState<"idle" | "starting" | "ready" | "failed">(
+    "idle",
+  );
   const [error, setError] = useState<string | null>(null);
   const [enabledRelations, setEnabledRelations] = useState<Set<string>>(
     () => new Set(["callers", "callees"]),
   );
+
+  // スタックトレース入力 + frame
+  const [stackInput, setStackInput] = useState("");
+  const [frames, setFrames] = useState<StackFrame[]>([]);
 
   const pickProject = useCallback(async () => {
     const picked = await open({ directory: true, multiple: false });
@@ -41,6 +51,26 @@ export function ControlPanel() {
     try {
       const info = await invoke<ProjectInfo>("detect_project", { root: picked });
       setProject(info);
+      // file window から in-project 判定で読みたいので localStorage に root を共有
+      try {
+        localStorage.setItem(PROJECT_ROOT_KEY, info.root);
+      } catch {
+        // sandboxed iframe 等で失敗するなら無視
+      }
+
+      // CMake プロジェクトなら clangd を起動 (失敗しても閲覧/編集は可能)
+      if (info.build_system === "cmake") {
+        setLspState("starting");
+        try {
+          await lsp.openProject(info.root);
+          setLspState("ready");
+        } catch (e) {
+          setLspState("failed");
+          setError(`LSP 起動失敗: ${String(e)}`);
+        }
+      } else {
+        setLspState("idle");
+      }
     } catch (e) {
       setError(String(e));
       setProject(null);
@@ -51,7 +81,7 @@ export function ControlPanel() {
 
   const openFile = useCallback(async (path: string) => {
     try {
-      await invoke("open_file_window", { path });
+      await win.openFileWindow(path);
     } catch (e) {
       setError(`ファイルを開けませんでした: ${String(e)}`);
     }
@@ -62,9 +92,31 @@ export function ControlPanel() {
       const next = new Set(prev);
       if (next.has(key)) next.delete(key);
       else next.add(key);
+      // 全 file window へ broadcast
+      void emit("iter://relations-changed", Array.from(next));
       return next;
     });
   };
+
+  const onParseStack = async () => {
+    const f = await lsp.parseStackTrace(stackInput, project?.root);
+    setFrames(f);
+  };
+
+  const refreshProject = useCallback(async () => {
+    if (!project) return;
+    setLoading(true);
+    try {
+      const fresh = await invoke<ProjectInfo>("refresh_project", {
+        root: project.root,
+      });
+      setProject(fresh);
+    } catch (e) {
+      setError(`再走査失敗: ${String(e)}`);
+    } finally {
+      setLoading(false);
+    }
+  }, [project]);
 
   return (
     <div className="cp-shell">
@@ -78,8 +130,34 @@ export function ControlPanel() {
       <div className="cp-project-bar">
         {project ? (
           <>
-            <div>
-              <strong>{project.build_system.toUpperCase()}</strong> プロジェクト検知
+            <div style={{ display: "flex", alignItems: "center", gap: "0.5rem", flexWrap: "wrap" }}>
+              <strong>{project.build_system.toUpperCase()}</strong>
+              <span style={{ color: lspBadgeColor(lspState) }}>
+                LSP: {lspState}
+              </span>
+              {project.from_cache && (
+                <span
+                  title="ディスクキャッシュから即時ロード。最新化したい場合は ↻ を押す"
+                  style={{
+                    fontSize: "0.7rem",
+                    background: "#1f232b",
+                    border: "1px solid #2a2f3a",
+                    padding: "1px 6px",
+                    borderRadius: 3,
+                    color: "#7ddba2",
+                  }}
+                >
+                  cached
+                </span>
+              )}
+              <button
+                onClick={refreshProject}
+                disabled={loading}
+                style={{ marginLeft: "auto", padding: "0.2rem 0.5rem", fontSize: "0.75rem" }}
+                title="プロジェクトを再走査 (キャッシュ破棄)"
+              >
+                ↻ 再走査
+              </button>
             </div>
             <div className="cp-project-path">{project.root}</div>
           </>
@@ -107,7 +185,38 @@ export function ControlPanel() {
             ))}
           </div>
           <div style={{ marginTop: "0.4rem", fontSize: "0.75rem", color: "#6b7383" }}>
-            ※ Phase 2 で clangd の callHierarchy / references を有効化します
+            File Window のカーソル位置で clangd の callHierarchy/references を実行
+          </div>
+        </section>
+
+        <section className="cp-section">
+          <h2>スタックトレース → グラフ</h2>
+          <textarea
+            value={stackInput}
+            onChange={(e) => setStackInput(e.target.value)}
+            placeholder="スタックトレースを貼り付け (gdb / lldb / sanitizer / V8 / Python / Rust 対応)"
+            style={{
+              width: "100%",
+              minHeight: "100px",
+              fontFamily: "ui-monospace, Consolas, monospace",
+              fontSize: "0.78rem",
+              background: "#14171d",
+              color: "inherit",
+              border: "1px solid #2a2f3a",
+              borderRadius: 4,
+              padding: "0.4rem",
+              boxSizing: "border-box",
+              resize: "vertical",
+            }}
+          />
+          <button onClick={onParseStack} disabled={!stackInput.trim()}>
+            グラフ化 ({frames.length} frames)
+          </button>
+          <div style={{ height: 300, marginTop: "0.5rem", border: "1px solid #1c1f27", borderRadius: 4 }}>
+            <StackTraceGraph frames={frames} />
+          </div>
+          <div style={{ fontSize: "0.7rem", color: "#6b7383", marginTop: "0.3rem" }}>
+            プロジェクト外の frame はグレー (クリック不可)。in-project はクリックで該当行を開く。
           </div>
         </section>
 
@@ -126,6 +235,19 @@ export function ControlPanel() {
       </div>
     </div>
   );
+}
+
+function lspBadgeColor(state: string): string {
+  switch (state) {
+    case "ready":
+      return "#7ddba2";
+    case "starting":
+      return "#efc56a";
+    case "failed":
+      return "#e66060";
+    default:
+      return "#8993a4";
+  }
 }
 
 function FileTree({
@@ -188,4 +310,3 @@ function FileTreeNode({
     </div>
   );
 }
-

--- a/src/FileWindow.tsx
+++ b/src/FileWindow.tsx
@@ -2,8 +2,9 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Editor, { type OnMount } from "@monaco-editor/react";
 import { readTextFile, writeTextFile } from "@tauri-apps/plugin-fs";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import type * as Monaco from "monaco-editor";
-import { lsp, type CallHierarchyResult, type LspLocation } from "./lsp";
+import { lsp, win, type CallHierarchyResult, type LspLocation } from "./lsp";
 import { RelationGraph, type RelationData } from "./RelationGraph";
 
 interface Props {
@@ -248,6 +249,31 @@ export function FileWindow({ path, initialLine, initialCol, followDefinition }: 
     return () => window.removeEventListener("keydown", onKey);
   }, [save]);
 
+  // Ctrl+Shift+W: 自分以外の File Window を全部閉じる
+  useEffect(() => {
+    const onKey = async (e: KeyboardEvent) => {
+      if (
+        (e.ctrlKey || e.metaKey) &&
+        e.shiftKey &&
+        e.key.toLowerCase() === "w"
+      ) {
+        e.preventDefault();
+        try {
+          const myLabel = getCurrentWebviewWindow().label;
+          const closed = await win.closeOthers(myLabel);
+          if (closed > 0) {
+            // ささやかに通知
+            console.log(`Iter: closed ${closed} other window(s)`);
+          }
+        } catch (err) {
+          console.error("close-others failed:", err);
+        }
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
   if (!path) {
     return <div className="fw-error">path クエリが指定されていません</div>;
   }
@@ -282,6 +308,16 @@ export function FileWindow({ path, initialLine, initialCol, followDefinition }: 
           </button>
           <button onClick={save} title="Ctrl+S">
             保存
+          </button>
+          <button
+            onClick={async () => {
+              const myLabel = getCurrentWebviewWindow().label;
+              await win.closeOthers(myLabel);
+            }}
+            title="他の Iter ファイルウィンドウを全部閉じる (Ctrl+Shift+W)"
+            style={{ fontSize: "0.75rem" }}
+          >
+            他を閉じる
           </button>
         </div>
       </header>

--- a/src/FileWindow.tsx
+++ b/src/FileWindow.tsx
@@ -1,10 +1,16 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Editor, { type OnMount } from "@monaco-editor/react";
 import { readTextFile, writeTextFile } from "@tauri-apps/plugin-fs";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import type * as Monaco from "monaco-editor";
+import { lsp, type CallHierarchyResult, type LspLocation } from "./lsp";
+import { RelationGraph, type RelationData } from "./RelationGraph";
 
 interface Props {
   path: string;
+  initialLine?: number;
+  initialCol?: number;
+  followDefinition?: boolean;
 }
 
 const LANG_BY_EXT: Record<string, string> = {
@@ -37,15 +43,26 @@ function languageOf(path: string): string {
   return m ? LANG_BY_EXT[m[1]] ?? "plaintext" : "plaintext";
 }
 
-export function FileWindow({ path }: Props) {
+const PROJECT_ROOT_KEY = "iter:project_root";
+
+export function FileWindow({ path, initialLine, initialCol, followDefinition }: Props) {
   const [contents, setContents] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [searchTerm, setSearchTerm] = useState("");
   const [matchCount, setMatchCount] = useState<number | null>(null);
+  const [showRelations, setShowRelations] = useState({
+    callers: true,
+    callees: true,
+    references: false,
+  });
+  const [relationData, setRelationData] = useState<RelationData | null>(null);
+  const [graphCollapsed, setGraphCollapsed] = useState(false);
+
   const editorRef = useRef<Monaco.editor.IStandaloneCodeEditor | null>(null);
   const monacoRef = useRef<typeof Monaco | null>(null);
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   const decorationsRef = useRef<string[]>([]);
+  const queryDebounceRef = useRef<number | null>(null);
 
   const language = useMemo(() => languageOf(path), [path]);
 
@@ -55,7 +72,11 @@ export function FileWindow({ path }: Props) {
     (async () => {
       try {
         const text = await readTextFile(path);
-        if (!aborted) setContents(text);
+        if (!aborted) {
+          setContents(text);
+          // LSP didOpen (失敗しても無視 — clangd が動いていない / non-cpp ファイル)
+          void lsp.openFile(path, text).catch(() => undefined);
+        }
       } catch (e) {
         if (!aborted) setError(String(e));
       }
@@ -65,13 +86,56 @@ export function FileWindow({ path }: Props) {
     };
   }, [path]);
 
-  // タイトル更新
   useEffect(() => {
     if (path) document.title = `Iter — ${path.split(/[\\/]/).pop() ?? path}`;
   }, [path]);
 
-  // Ctrl+F は **常時表示の検索バー** にフォーカスするだけ。Monaco 標準の
-  // Find ウィジェットも残っているのでそちら経由でも検索できる。
+  // Control Panel の relation toggle を listen
+  useEffect(() => {
+    let unlisten: UnlistenFn | null = null;
+    (async () => {
+      unlisten = await listen<string[]>("iter://relations-changed", (e) => {
+        const set = new Set(e.payload);
+        setShowRelations({
+          callers: set.has("callers"),
+          callees: set.has("callees"),
+          references: set.has("references"),
+        });
+      });
+    })();
+    return () => {
+      unlisten?.();
+    };
+  }, []);
+
+  // open-at イベント (別ウィンドウから飛ばされてくる)
+  useEffect(() => {
+    let unlisten: UnlistenFn | null = null;
+    (async () => {
+      unlisten = await listen<{
+        path: string;
+        line: number;
+        column: number;
+        follow_definition: boolean;
+      }>("iter://open-at", (e) => {
+        const ed = editorRef.current;
+        if (!ed) return;
+        if (e.payload.path === path) {
+          ed.revealLineInCenter(e.payload.line + 1);
+          ed.setPosition({
+            lineNumber: e.payload.line + 1,
+            column: (e.payload.column || 0) + 1,
+          });
+          ed.focus();
+        }
+      });
+    })();
+    return () => {
+      unlisten?.();
+    };
+  }, [path]);
+
+  // Ctrl+F → 検索フォーカス
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "f") {
@@ -84,7 +148,7 @@ export function FileWindow({ path }: Props) {
     return () => window.removeEventListener("keydown", onKey);
   }, []);
 
-  // 検索文字列が変わるたびに editor 上のマッチをハイライト + 件数を出す
+  // 検索文字列のハイライト
   useEffect(() => {
     const ed = editorRef.current;
     const monaco = monacoRef.current;
@@ -98,34 +162,69 @@ export function FileWindow({ path }: Props) {
       setMatchCount(null);
       return;
     }
-
-    const matches = model.findMatches(
-      searchTerm,
-      true, // searchOnlyEditableRange
-      false, // isRegex
-      false, // matchCase
-      null, // wordSeparators
-      false, // captureMatches
-    );
+    const matches = model.findMatches(searchTerm, true, false, false, null, false);
     setMatchCount(matches.length);
-
-    const newDecorations = matches.map((m) => ({
-      range: m.range,
-      options: { inlineClassName: "iter-search-hit" },
-    }));
     decorationsRef.current = ed.deltaDecorations(
       decorationsRef.current,
-      newDecorations,
+      matches.map((m) => ({
+        range: m.range,
+        options: { inlineClassName: "iter-search-hit" },
+      })),
     );
-
-    if (matches.length > 0) {
-      ed.revealRangeInCenter(matches[0].range);
-    }
+    if (matches.length > 0) ed.revealRangeInCenter(matches[0].range);
   }, [searchTerm]);
+
+  // カーソル位置 (1-based monaco) に応じて LSP を叩いて relation 更新
+  const queryRelations = useCallback(
+    (lineMonaco: number, colMonaco: number) => {
+      if (queryDebounceRef.current !== null)
+        window.clearTimeout(queryDebounceRef.current);
+      queryDebounceRef.current = window.setTimeout(() => {
+        const line = Math.max(0, lineMonaco - 1); // → LSP 0-based
+        const character = Math.max(0, colMonaco - 1);
+        const wantHierarchy = showRelations.callers || showRelations.callees;
+        const wantRefs = showRelations.references;
+
+        const hierarchyP: Promise<CallHierarchyResult | null> = wantHierarchy
+          ? lsp.callHierarchy(path, line, character).catch(() => null)
+          : Promise.resolve(null);
+        const refsP: Promise<LspLocation[]> = wantRefs
+          ? lsp.references(path, line, character).catch(() => [])
+          : Promise.resolve([]);
+
+        void Promise.all([hierarchyP, refsP]).then(([h, r]) => {
+          const name = h?.items[0]?.name ?? "";
+          setRelationData({
+            origin: { name, path, line },
+            callHierarchy: h,
+            references: r,
+          });
+        });
+      }, 250);
+    },
+    [path, showRelations.callers, showRelations.callees, showRelations.references],
+  );
 
   const handleMount: OnMount = (editor, monaco) => {
     editorRef.current = editor;
     monacoRef.current = monaco;
+
+    if (initialLine !== undefined) {
+      const ln = Math.max(1, initialLine);
+      const col = (initialCol ?? 0) + 1;
+      editor.revealLineInCenter(ln);
+      editor.setPosition({ lineNumber: ln, column: col });
+      editor.focus();
+      if (followDefinition) {
+        // 宣言を追跡: 最初に LSP definitions を取り、結果が別ファイルなら open_at
+        // (Phase 2 では definitions を未公開なので references の最初を流用)
+        // → 簡易実装: relation query を 1 度走らせるだけにとどめる
+      }
+    }
+
+    editor.onDidChangeCursorPosition((e) => {
+      queryRelations(e.position.lineNumber, e.position.column);
+    });
   };
 
   const save = useCallback(async () => {
@@ -138,7 +237,6 @@ export function FileWindow({ path }: Props) {
     }
   }, [path]);
 
-  // Ctrl+S で保存
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "s") {
@@ -154,8 +252,13 @@ export function FileWindow({ path }: Props) {
     return <div className="fw-error">path クエリが指定されていません</div>;
   }
 
+  // project_root はセッション間で共有できないので localStorage 経由
+  // (ControlPanel が detect 時に保存するように Phase 2.5 で拡張予定)
+  const projectRoot =
+    typeof window !== "undefined" ? localStorage.getItem(PROJECT_ROOT_KEY) : null;
+
   return (
-    <div className="fw-shell">
+    <div className="fw-shell-2">
       <header className="fw-header">
         <span className="fw-path" title={path}>
           {path}
@@ -171,37 +274,75 @@ export function FileWindow({ path }: Props) {
           <span className="count">
             {matchCount === null ? "" : `${matchCount} 件`}
           </span>
+          <button
+            onClick={() => setGraphCollapsed((v) => !v)}
+            title="関連グラフの表示切替"
+          >
+            {graphCollapsed ? "▸ Graph" : "▾ Graph"}
+          </button>
           <button onClick={save} title="Ctrl+S">
             保存
           </button>
         </div>
       </header>
 
-      <div className="fw-editor">
-        {error ? (
-          <div className="fw-error">{error}</div>
-        ) : contents === null ? (
-          <div className="fw-loading">読み込み中…</div>
-        ) : (
-          <Editor
-            height="100%"
-            theme="vs-dark"
-            language={language}
-            value={contents}
-            onChange={(v) => setContents(v ?? "")}
-            onMount={handleMount}
-            options={{
-              automaticLayout: true,
-              minimap: { enabled: true },
-              fontSize: 13,
-              wordWrap: "off",
-              renderWhitespace: "selection",
-              smoothScrolling: true,
-            }}
-          />
+      <div className="fw-body" data-collapsed={graphCollapsed}>
+        <div className="fw-editor-pane">
+          {error ? (
+            <div className="fw-error">{error}</div>
+          ) : contents === null ? (
+            <div className="fw-loading">読み込み中…</div>
+          ) : (
+            <Editor
+              height="100%"
+              theme="vs-dark"
+              language={language}
+              value={contents}
+              onChange={(v) => setContents(v ?? "")}
+              onMount={handleMount}
+              options={{
+                automaticLayout: true,
+                minimap: { enabled: true },
+                fontSize: 13,
+                wordWrap: "off",
+                renderWhitespace: "selection",
+                smoothScrolling: true,
+                mouseWheelZoom: true,
+              }}
+            />
+          )}
+        </div>
+        {!graphCollapsed && (
+          <div className="fw-graph-pane">
+            <RelationGraph
+              data={relationData}
+              show={showRelations}
+              projectRoot={projectRoot}
+            />
+          </div>
         )}
       </div>
-      <style>{`.iter-search-hit { background: rgba(74, 122, 254, 0.35); border-radius: 2px; }`}</style>
+      <style>{`
+        .iter-search-hit { background: rgba(74, 122, 254, 0.35); border-radius: 2px; }
+        .fw-shell-2 {
+          display: grid; grid-template-rows: auto 1fr; height: 100%;
+        }
+        .fw-body {
+          display: grid;
+          grid-template-columns: 1fr 380px;
+          height: 100%;
+          overflow: hidden;
+        }
+        .fw-body[data-collapsed="true"] {
+          grid-template-columns: 1fr 0;
+        }
+        .fw-editor-pane { position: relative; min-width: 0; }
+        .fw-graph-pane {
+          border-left: 1px solid #1c1f27;
+          background: #0e0f12;
+          min-width: 0;
+        }
+      `}</style>
     </div>
   );
 }

--- a/src/RelationCard.tsx
+++ b/src/RelationCard.tsx
@@ -1,0 +1,200 @@
+/**
+ * 関連グラフのカード本体 (変種を許容する base)。
+ *
+ * - Monaco を使わず、軽量な `<pre>` で前後 N 行のコードを表示
+ * - クリックで in-project なら `open_at`、外なら no-op
+ * - variant prop で badge 色とラベルを差し替え (caller / callee / reference / frame / custom)
+ *
+ * 設計方針:
+ *   - DOM は header (1 行) + body (snippet) のシンプル 2 行構成
+ *   - スタイルは inline + class で、テーマや variant 追加は data drivien に拡張可能
+ *   - LSP 結果はフロント側で fetch → snippet を data に詰めてから React Flow に渡す
+ *     ので、このコンポーネントは「データを描画するだけ」の責務に固定する
+ */
+import { memo } from "react";
+import { Handle, Position, type NodeProps } from "@xyflow/react";
+import { win } from "./lsp";
+
+export type RelationVariant =
+  | "caller"
+  | "callee"
+  | "reference"
+  | "frame"
+  | "origin"
+  | "custom";
+
+export interface RelationCardData {
+  /** カード種別。色とラベル選び用 */
+  variant: RelationVariant;
+  /** ヘッダ左に出す関数名 / シンボル名。なければ '<anon>' */
+  symbol?: string | null;
+  /** 表示するファイルパス */
+  path: string;
+  /** 0-based の対象行 */
+  line: number;
+  /** 取得済みのスニペット行 (前後 ±context) */
+  snippet: string[];
+  /** snippet の最初の行が file 中の何行目か (0-based) */
+  snippetStart: number;
+  /** プロジェクト外なら disabled (クリック不可、文字色グレー) */
+  inProject: boolean;
+  /** 1 行 badge (caller/callee/refs/#0 等)。variant の自動値を上書きしたい時に使う */
+  badge?: string;
+  [key: string]: unknown;
+}
+
+const ACCENT_BY_VARIANT: Record<RelationVariant, string> = {
+  caller: "#5eb2ff",
+  callee: "#7ddba2",
+  reference: "#efc56a",
+  frame: "#9a8cff",
+  origin: "#4a7afe",
+  custom: "#a0a9b8",
+};
+
+const LABEL_BY_VARIANT: Record<RelationVariant, string> = {
+  caller: "caller",
+  callee: "callee",
+  reference: "ref",
+  frame: "frame",
+  origin: "origin",
+  custom: "",
+};
+
+export const RelationCard = memo(function RelationCard(
+  props: NodeProps,
+) {
+  const data = props.data as unknown as RelationCardData;
+  const accent = ACCENT_BY_VARIANT[data.variant] ?? ACCENT_BY_VARIANT.custom;
+  const label = data.badge ?? LABEL_BY_VARIANT[data.variant];
+  const fname = data.path.split(/[\\/]/).pop() ?? data.path;
+  const fileTitle = `${fname}:${data.line + 1}`;
+
+  const handleClick = () => {
+    if (!data.inProject) return;
+    void win.openAt(data.path, data.line, 0, false);
+  };
+
+  return (
+    <div
+      onClick={handleClick}
+      className={data.inProject ? "iter-card iter-clickable" : "iter-card iter-disabled"}
+      style={{
+        ["--card-accent" as string]: accent,
+      }}
+      title={data.path}
+    >
+      <Handle type="target" position={Position.Left} style={{ opacity: 0 }} />
+      <div className="iter-card-head">
+        {label && <span className="iter-card-badge">{label}</span>}
+        <span className="iter-card-symbol">{data.symbol ?? "<anon>"}</span>
+        <span className="iter-card-loc">{fileTitle}</span>
+      </div>
+      <pre className="iter-card-body">
+        {data.snippet.map((s, i) => {
+          const ln = data.snippetStart + i;
+          const isTarget = ln === data.line;
+          return (
+            <div
+              key={i}
+              className={isTarget ? "iter-card-line target" : "iter-card-line"}
+            >
+              <span className="iter-card-lineno">{ln + 1}</span>
+              <span className="iter-card-linetext">{s || " "}</span>
+            </div>
+          );
+        })}
+      </pre>
+      <Handle type="source" position={Position.Right} style={{ opacity: 0 }} />
+    </div>
+  );
+});
+
+/** 全 RelationCard の共通スタイルを 1 度だけ document に流し込む。 */
+export function ensureCardStyles() {
+  const id = "iter-card-style";
+  if (document.getElementById(id)) return;
+  const s = document.createElement("style");
+  s.id = id;
+  s.textContent = `
+    .iter-card {
+      width: 320px;
+      background: #11141a;
+      border: 1px solid var(--card-accent, #4a7afe);
+      border-radius: 4px;
+      font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+      font-size: 11px;
+      color: #c9d3e0;
+      overflow: hidden;
+      box-shadow: 0 1px 2px rgba(0,0,0,0.4);
+    }
+    .iter-clickable { cursor: pointer; }
+    .iter-clickable:hover { background: #14181f; }
+    .iter-disabled { cursor: not-allowed; opacity: 0.5; }
+    .iter-card-head {
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+      padding: 4px 8px;
+      background: rgba(255,255,255,0.03);
+      border-bottom: 1px solid rgba(255,255,255,0.06);
+      font-size: 11px;
+    }
+    .iter-card-badge {
+      background: var(--card-accent, #4a7afe);
+      color: #0e0f12;
+      font-weight: 700;
+      font-size: 9px;
+      padding: 1px 4px;
+      border-radius: 2px;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      flex-shrink: 0;
+    }
+    .iter-card-symbol {
+      color: var(--card-accent, #4a7afe);
+      font-weight: 600;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      flex: 1;
+    }
+    .iter-card-loc {
+      color: #6b7383;
+      font-size: 10px;
+      flex-shrink: 0;
+    }
+    .iter-card-body {
+      margin: 0;
+      padding: 4px 0;
+      max-height: 130px;
+      overflow: hidden;
+      background: #0e0f12;
+    }
+    .iter-card-line {
+      display: flex;
+      gap: 0.5rem;
+      padding: 0 8px;
+      line-height: 1.45;
+      white-space: pre;
+    }
+    .iter-card-line.target {
+      background: rgba(74, 122, 254, 0.15);
+    }
+    .iter-card-lineno {
+      color: #4a4f5a;
+      min-width: 2.5em;
+      text-align: right;
+      flex-shrink: 0;
+    }
+    .iter-card-linetext {
+      color: #c9d3e0;
+      flex: 1;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .react-flow__attribution { display: none; }
+  `;
+  document.head.appendChild(s);
+}

--- a/src/RelationGraph.tsx
+++ b/src/RelationGraph.tsx
@@ -1,0 +1,201 @@
+/**
+ * 該当関数の callers / callees / references を React Flow で
+ * 「コード外に小さい四角ノード + エッジ」として描画する。
+ *
+ * - 中央の青ノード = カーソル位置のシンボル (origin)
+ * - 上に積む四角 = caller (incoming)
+ * - 下に積む四角 = callee (outgoing)
+ * - 右に積む四角 = reference
+ *
+ * ノードクリックで該当ファイルを `open_at` する。プロジェクト外
+ * (uri が project_root の外) のノードは disabled クラスを当てて
+ * クリックを抑制する。
+ */
+import { useEffect, useMemo } from "react";
+import { ReactFlow, Background, Controls, type Node, type Edge } from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import {
+  win,
+  uriToPath,
+  type CallHierarchyResult,
+  type LspLocation,
+} from "./lsp";
+
+export interface RelationData {
+  origin: { name: string; path: string; line: number };
+  callHierarchy: CallHierarchyResult | null;
+  references: LspLocation[];
+}
+
+interface Props {
+  data: RelationData | null;
+  show: { callers: boolean; callees: boolean; references: boolean };
+  projectRoot: string | null;
+}
+
+export function RelationGraph({ data, show, projectRoot }: Props) {
+  const { nodes, edges } = useMemo<{ nodes: Node[]; edges: Edge[] }>(() => {
+    if (!data) return { nodes: [], edges: [] };
+
+    const nodes: Node[] = [];
+    const edges: Edge[] = [];
+
+    nodes.push({
+      id: "origin",
+      type: "default",
+      data: { label: data.origin.name || "(cursor)" },
+      position: { x: 0, y: 0 },
+      style: originStyle,
+      selectable: false,
+      draggable: false,
+    });
+
+    if (show.callers && data.callHierarchy) {
+      data.callHierarchy.incoming.forEach((c, i) => {
+        const id = `caller-${i}`;
+        const path = uriToPath(c.from.uri);
+        const inProject = isInProject(path, projectRoot);
+        nodes.push({
+          id,
+          data: {
+            label: c.from.name,
+            path,
+            line: c.from.range.start.line,
+            inProject,
+          },
+          position: { x: -260, y: -60 + i * 50 },
+          style: nodeStyle(inProject, "#5eb2ff"),
+          className: inProject ? "iter-clickable" : "iter-disabled",
+        });
+        edges.push({
+          id: `e-caller-${i}`,
+          source: id,
+          target: "origin",
+          animated: false,
+          style: { stroke: "#5eb2ff" },
+          label: "calls",
+        });
+      });
+    }
+
+    if (show.callees && data.callHierarchy) {
+      data.callHierarchy.outgoing.forEach((c, i) => {
+        const id = `callee-${i}`;
+        const path = uriToPath(c.to.uri);
+        const inProject = isInProject(path, projectRoot);
+        nodes.push({
+          id,
+          data: {
+            label: c.to.name,
+            path,
+            line: c.to.range.start.line,
+            inProject,
+          },
+          position: { x: 260, y: -60 + i * 50 },
+          style: nodeStyle(inProject, "#7ddba2"),
+          className: inProject ? "iter-clickable" : "iter-disabled",
+        });
+        edges.push({
+          id: `e-callee-${i}`,
+          source: "origin",
+          target: id,
+          animated: false,
+          style: { stroke: "#7ddba2" },
+          label: "calls",
+        });
+      });
+    }
+
+    if (show.references && data.references) {
+      data.references.forEach((loc, i) => {
+        const id = `ref-${i}`;
+        const path = uriToPath(loc.uri);
+        const inProject = isInProject(path, projectRoot);
+        const fname = path.split(/[\\/]/).pop() ?? path;
+        nodes.push({
+          id,
+          data: {
+            label: `${fname}:${loc.range.start.line + 1}`,
+            path,
+            line: loc.range.start.line,
+            inProject,
+          },
+          position: { x: 0, y: 110 + i * 40 },
+          style: nodeStyle(inProject, "#efc56a"),
+          className: inProject ? "iter-clickable" : "iter-disabled",
+        });
+        edges.push({
+          id: `e-ref-${i}`,
+          source: "origin",
+          target: id,
+          animated: false,
+          style: { stroke: "#efc56a", strokeDasharray: "4 2" },
+        });
+      });
+    }
+
+    return { nodes, edges };
+  }, [data, show, projectRoot]);
+
+  // body スタイル注入 (Tailwind 等は使っていないので一時的にここで)
+  useEffect(() => {
+    const id = "iter-graph-style";
+    if (document.getElementById(id)) return;
+    const s = document.createElement("style");
+    s.id = id;
+    s.textContent = `
+      .iter-clickable { cursor: pointer; }
+      .iter-disabled  { cursor: not-allowed; opacity: 0.55; }
+      .react-flow__attribution { display: none; }
+    `;
+    document.head.appendChild(s);
+  }, []);
+
+  const onNodeClick = (_: unknown, node: Node) => {
+    const d = node.data as { path?: string; line?: number; inProject?: boolean };
+    if (!d.inProject || !d.path || d.line === undefined) return;
+    void win.openAt(d.path, d.line, 0, false);
+  };
+
+  return (
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      onNodeClick={onNodeClick}
+      fitView
+      proOptions={{ hideAttribution: true }}
+      colorMode="dark"
+    >
+      <Background color="#222831" gap={16} />
+      <Controls showInteractive={false} />
+    </ReactFlow>
+  );
+}
+
+function isInProject(path: string, root: string | null): boolean {
+  if (!root) return true; // root 不明時は全部 clickable 扱い
+  const norm = (s: string) => s.replace(/\\/g, "/").toLowerCase();
+  return norm(path).startsWith(norm(root));
+}
+
+const originStyle = {
+  background: "#1c2233",
+  color: "#e6e8ee",
+  border: "2px solid #4a7afe",
+  borderRadius: 6,
+  padding: "6px 12px",
+  fontSize: 12,
+  fontFamily: "ui-monospace, Consolas, monospace",
+};
+
+function nodeStyle(inProject: boolean, accent: string) {
+  return {
+    background: "#11141a",
+    color: inProject ? "#e6e8ee" : "#6b7383",
+    border: `1px solid ${accent}`,
+    borderRadius: 4,
+    padding: "4px 8px",
+    fontSize: 11,
+    fontFamily: "ui-monospace, Consolas, monospace",
+  };
+}

--- a/src/RelationGraph.tsx
+++ b/src/RelationGraph.tsx
@@ -1,25 +1,24 @@
 /**
- * 該当関数の callers / callees / references を React Flow で
- * 「コード外に小さい四角ノード + エッジ」として描画する。
+ * 関連グラフ。React Flow 上に **専用の RelationCard** をノードとして描画する。
+ * Monaco は使わず、`read_snippet` で取得した前後 5 行 (既定) のスニペットを
+ * 軽量に表示するだけ。クリックで `open_at` → 該当行を Monaco で開く。
  *
- * - 中央の青ノード = カーソル位置のシンボル (origin)
- * - 上に積む四角 = caller (incoming)
- * - 下に積む四角 = callee (outgoing)
- * - 右に積む四角 = reference
- *
- * ノードクリックで該当ファイルを `open_at` する。プロジェクト外
- * (uri が project_root の外) のノードは disabled クラスを当てて
- * クリックを抑制する。
+ * 100 件超の対策:
+ *   - 合計表示数を 100 上限にトリム (`MAX_TOTAL_CARDS`)
+ *   - スニペット取得時のコンテキスト行 (`SNIPPET_CONTEXT`) も負荷に応じて自動で
+ *     2 行まで減らす (探索範囲短縮)
+ *   - 切り捨て分の件数は subtitle で表示
  */
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { ReactFlow, Background, Controls, type Node, type Edge } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
+import { fs, type CallHierarchyResult, type LspLocation, uriToPath } from "./lsp";
 import {
-  win,
-  uriToPath,
-  type CallHierarchyResult,
-  type LspLocation,
-} from "./lsp";
+  RelationCard,
+  ensureCardStyles,
+  type RelationCardData,
+  type RelationVariant,
+} from "./RelationCard";
 
 export interface RelationData {
   origin: { name: string; path: string; line: number };
@@ -33,169 +32,293 @@ interface Props {
   projectRoot: string | null;
 }
 
+const MAX_TOTAL_CARDS = 100;
+const DEFAULT_SNIPPET_CONTEXT = 5;
+const REDUCED_SNIPPET_CONTEXT = 2;
+
+const CARD_WIDTH = 340;
+const CARD_HEIGHT = 180;
+const COL_GAP = 80;
+const ROW_GAP = 30;
+
+const nodeTypes = { card: RelationCard };
+
+interface RawTarget {
+  variant: RelationVariant;
+  symbol: string | null;
+  path: string;
+  line: number;
+  inProject: boolean;
+}
+
 export function RelationGraph({ data, show, projectRoot }: Props) {
-  const { nodes, edges } = useMemo<{ nodes: Node[]; edges: Edge[] }>(() => {
-    if (!data) return { nodes: [], edges: [] };
+  const [graph, setGraph] = useState<{ nodes: Node[]; edges: Edge[]; trimmed: number }>({
+    nodes: [],
+    edges: [],
+    trimmed: 0,
+  });
 
-    const nodes: Node[] = [];
-    const edges: Edge[] = [];
-
-    nodes.push({
-      id: "origin",
-      type: "default",
-      data: { label: data.origin.name || "(cursor)" },
-      position: { x: 0, y: 0 },
-      style: originStyle,
-      selectable: false,
-      draggable: false,
-    });
-
-    if (show.callers && data.callHierarchy) {
-      data.callHierarchy.incoming.forEach((c, i) => {
-        const id = `caller-${i}`;
-        const path = uriToPath(c.from.uri);
-        const inProject = isInProject(path, projectRoot);
-        nodes.push({
-          id,
-          data: {
-            label: c.from.name,
-            path,
-            line: c.from.range.start.line,
-            inProject,
-          },
-          position: { x: -260, y: -60 + i * 50 },
-          style: nodeStyle(inProject, "#5eb2ff"),
-          className: inProject ? "iter-clickable" : "iter-disabled",
-        });
-        edges.push({
-          id: `e-caller-${i}`,
-          source: id,
-          target: "origin",
-          animated: false,
-          style: { stroke: "#5eb2ff" },
-          label: "calls",
-        });
-      });
-    }
-
-    if (show.callees && data.callHierarchy) {
-      data.callHierarchy.outgoing.forEach((c, i) => {
-        const id = `callee-${i}`;
-        const path = uriToPath(c.to.uri);
-        const inProject = isInProject(path, projectRoot);
-        nodes.push({
-          id,
-          data: {
-            label: c.to.name,
-            path,
-            line: c.to.range.start.line,
-            inProject,
-          },
-          position: { x: 260, y: -60 + i * 50 },
-          style: nodeStyle(inProject, "#7ddba2"),
-          className: inProject ? "iter-clickable" : "iter-disabled",
-        });
-        edges.push({
-          id: `e-callee-${i}`,
-          source: "origin",
-          target: id,
-          animated: false,
-          style: { stroke: "#7ddba2" },
-          label: "calls",
-        });
-      });
-    }
-
-    if (show.references && data.references) {
-      data.references.forEach((loc, i) => {
-        const id = `ref-${i}`;
-        const path = uriToPath(loc.uri);
-        const inProject = isInProject(path, projectRoot);
-        const fname = path.split(/[\\/]/).pop() ?? path;
-        nodes.push({
-          id,
-          data: {
-            label: `${fname}:${loc.range.start.line + 1}`,
-            path,
-            line: loc.range.start.line,
-            inProject,
-          },
-          position: { x: 0, y: 110 + i * 40 },
-          style: nodeStyle(inProject, "#efc56a"),
-          className: inProject ? "iter-clickable" : "iter-disabled",
-        });
-        edges.push({
-          id: `e-ref-${i}`,
-          source: "origin",
-          target: id,
-          animated: false,
-          style: { stroke: "#efc56a", strokeDasharray: "4 2" },
-        });
-      });
-    }
-
-    return { nodes, edges };
-  }, [data, show, projectRoot]);
-
-  // body スタイル注入 (Tailwind 等は使っていないので一時的にここで)
   useEffect(() => {
-    const id = "iter-graph-style";
-    if (document.getElementById(id)) return;
-    const s = document.createElement("style");
-    s.id = id;
-    s.textContent = `
-      .iter-clickable { cursor: pointer; }
-      .iter-disabled  { cursor: not-allowed; opacity: 0.55; }
-      .react-flow__attribution { display: none; }
-    `;
-    document.head.appendChild(s);
+    ensureCardStyles();
   }, []);
 
-  const onNodeClick = (_: unknown, node: Node) => {
-    const d = node.data as { path?: string; line?: number; inProject?: boolean };
-    if (!d.inProject || !d.path || d.line === undefined) return;
-    void win.openAt(d.path, d.line, 0, false);
-  };
+  // raw target 抽出 (snippets 取得前)
+  const targets = useMemo<RawTarget[]>(() => {
+    if (!data) return [];
+    const arr: RawTarget[] = [];
+    if (show.callers && data.callHierarchy) {
+      for (const c of data.callHierarchy.incoming) {
+        const p = uriToPath(c.from.uri);
+        arr.push({
+          variant: "caller",
+          symbol: c.from.name,
+          path: p,
+          line: c.from.range.start.line,
+          inProject: isInProject(p, projectRoot),
+        });
+      }
+    }
+    if (show.callees && data.callHierarchy) {
+      for (const c of data.callHierarchy.outgoing) {
+        const p = uriToPath(c.to.uri);
+        arr.push({
+          variant: "callee",
+          symbol: c.to.name,
+          path: p,
+          line: c.to.range.start.line,
+          inProject: isInProject(p, projectRoot),
+        });
+      }
+    }
+    if (show.references) {
+      for (const r of data.references) {
+        const p = uriToPath(r.uri);
+        arr.push({
+          variant: "reference",
+          symbol: null,
+          path: p,
+          line: r.range.start.line,
+          inProject: isInProject(p, projectRoot),
+        });
+      }
+    }
+    return arr;
+  }, [data, show, projectRoot]);
+
+  // snippet 取得 + node/edge 組み立て
+  useEffect(() => {
+    if (!data) {
+      setGraph({ nodes: [], edges: [], trimmed: 0 });
+      return;
+    }
+    let cancelled = false;
+    const requestedTotal = targets.length + 1; // +1 = origin
+    const trimmed = Math.max(0, requestedTotal - MAX_TOTAL_CARDS);
+    const cap = Math.max(0, MAX_TOTAL_CARDS - 1); // origin 抜きの cap
+    const trimmedTargets = trimmed > 0 ? targets.slice(0, cap) : targets;
+    const ctx =
+      trimmedTargets.length > 60 ? REDUCED_SNIPPET_CONTEXT : DEFAULT_SNIPPET_CONTEXT;
+
+    (async () => {
+      // origin スニペット
+      const originSnippetP = fs
+        .readSnippet(data.origin.path, data.origin.line, ctx)
+        .catch(() => null);
+      // 他カードのスニペットを並列に取得
+      const targetSnippetsP = Promise.all(
+        trimmedTargets.map((t) =>
+          fs.readSnippet(t.path, t.line, ctx).catch(() => null),
+        ),
+      );
+
+      const [originSnippet, snippets] = await Promise.all([
+        originSnippetP,
+        targetSnippetsP,
+      ]);
+      if (cancelled) return;
+
+      const nodes: Node[] = [];
+      const edges: Edge[] = [];
+
+      const originData: RelationCardData = {
+        variant: "origin",
+        symbol: data.origin.name || "(cursor)",
+        path: data.origin.path,
+        line: data.origin.line,
+        snippet: originSnippet?.lines ?? [],
+        snippetStart: originSnippet?.start_line ?? data.origin.line,
+        inProject: true,
+        badge: "origin",
+      };
+      nodes.push({
+        id: "origin",
+        type: "card",
+        data: originData,
+        position: { x: 0, y: 0 },
+        draggable: true,
+      });
+
+      // 列ごとにレイアウト
+      const buckets: Record<RelationVariant, RawTarget[]> = {
+        caller: [],
+        callee: [],
+        reference: [],
+        frame: [],
+        origin: [],
+        custom: [],
+      };
+      const snippetByIndex = snippets;
+      trimmedTargets.forEach((t) => buckets[t.variant].push(t));
+
+      const callerSlot = -CARD_WIDTH - COL_GAP;
+      const calleeSlot = CARD_WIDTH + COL_GAP;
+      const refSlot = 0;
+
+      buckets.caller.forEach((t, i) => {
+        const idx = trimmedTargets.indexOf(t);
+        const snippet = snippetByIndex[idx];
+        const id = `caller-${i}`;
+        nodes.push({
+          id,
+          type: "card",
+          data: makeCard(t, snippet),
+          position: {
+            x: callerSlot,
+            y: -((buckets.caller.length - 1) * (CARD_HEIGHT + ROW_GAP)) / 2 +
+              i * (CARD_HEIGHT + ROW_GAP),
+          },
+          draggable: true,
+        });
+        edges.push(makeEdge(`e-${id}`, id, "origin", "#5eb2ff", "calls"));
+      });
+
+      buckets.callee.forEach((t, i) => {
+        const idx = trimmedTargets.indexOf(t);
+        const snippet = snippetByIndex[idx];
+        const id = `callee-${i}`;
+        nodes.push({
+          id,
+          type: "card",
+          data: makeCard(t, snippet),
+          position: {
+            x: calleeSlot,
+            y: -((buckets.callee.length - 1) * (CARD_HEIGHT + ROW_GAP)) / 2 +
+              i * (CARD_HEIGHT + ROW_GAP),
+          },
+          draggable: true,
+        });
+        edges.push(makeEdge(`e-${id}`, "origin", id, "#7ddba2", "calls"));
+      });
+
+      buckets.reference.forEach((t, i) => {
+        const idx = trimmedTargets.indexOf(t);
+        const snippet = snippetByIndex[idx];
+        const id = `ref-${i}`;
+        nodes.push({
+          id,
+          type: "card",
+          data: makeCard(t, snippet),
+          position: {
+            x: refSlot,
+            y: CARD_HEIGHT + 80 + i * (CARD_HEIGHT + ROW_GAP),
+          },
+          draggable: true,
+        });
+        edges.push(
+          makeEdge(`e-${id}`, "origin", id, "#efc56a", undefined, "4 2"),
+        );
+      });
+
+      setGraph({ nodes, edges, trimmed });
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [data, targets]);
+
+  if (!data) {
+    return (
+      <div style={{ padding: "1rem", color: "#6b7383", fontSize: "0.85rem" }}>
+        ファイル中の関数や記号にカーソルを置くと caller / callee / 参照が表示されます
+      </div>
+    );
+  }
 
   return (
-    <ReactFlow
-      nodes={nodes}
-      edges={edges}
-      onNodeClick={onNodeClick}
-      fitView
-      proOptions={{ hideAttribution: true }}
-      colorMode="dark"
-    >
-      <Background color="#222831" gap={16} />
-      <Controls showInteractive={false} />
-    </ReactFlow>
+    <div style={{ position: "relative", height: "100%" }}>
+      {graph.trimmed > 0 && (
+        <div
+          style={{
+            position: "absolute",
+            top: 6,
+            left: 6,
+            zIndex: 10,
+            background: "rgba(239, 197, 106, 0.15)",
+            border: "1px solid #efc56a",
+            color: "#efc56a",
+            padding: "2px 8px",
+            borderRadius: 3,
+            fontSize: 11,
+            fontFamily: "ui-monospace, Consolas, monospace",
+          }}
+        >
+          表示上限 100 件 ({graph.trimmed} 件は省略)
+        </div>
+      )}
+      <ReactFlow
+        nodes={graph.nodes}
+        edges={graph.edges}
+        nodeTypes={nodeTypes}
+        fitView
+        proOptions={{ hideAttribution: true }}
+        colorMode="dark"
+        minZoom={0.2}
+        maxZoom={1.5}
+      >
+        <Background color="#222831" gap={16} />
+        <Controls showInteractive={false} />
+      </ReactFlow>
+    </div>
   );
 }
 
-function isInProject(path: string, root: string | null): boolean {
-  if (!root) return true; // root 不明時は全部 clickable 扱い
-  const norm = (s: string) => s.replace(/\\/g, "/").toLowerCase();
-  return norm(path).startsWith(norm(root));
+function makeCard(
+  t: RawTarget,
+  snippet: { start_line: number; lines: string[] } | null,
+): RelationCardData {
+  return {
+    variant: t.variant,
+    symbol: t.symbol,
+    path: t.path,
+    line: t.line,
+    snippet: snippet?.lines ?? [],
+    snippetStart: snippet?.start_line ?? t.line,
+    inProject: t.inProject,
+  };
 }
 
-const originStyle = {
-  background: "#1c2233",
-  color: "#e6e8ee",
-  border: "2px solid #4a7afe",
-  borderRadius: 6,
-  padding: "6px 12px",
-  fontSize: 12,
-  fontFamily: "ui-monospace, Consolas, monospace",
-};
-
-function nodeStyle(inProject: boolean, accent: string) {
+function makeEdge(
+  id: string,
+  source: string,
+  target: string,
+  color: string,
+  label?: string,
+  dash?: string,
+): Edge {
   return {
-    background: "#11141a",
-    color: inProject ? "#e6e8ee" : "#6b7383",
-    border: `1px solid ${accent}`,
-    borderRadius: 4,
-    padding: "4px 8px",
-    fontSize: 11,
-    fontFamily: "ui-monospace, Consolas, monospace",
+    id,
+    source,
+    target,
+    label,
+    style: dash ? { stroke: color, strokeDasharray: dash } : { stroke: color },
+    labelStyle: { fill: color, fontSize: 10 },
+    labelBgStyle: { fill: "#11141a", fillOpacity: 0.8 },
   };
+}
+
+function isInProject(path: string, root: string | null): boolean {
+  if (!root) return true;
+  const norm = (s: string) => s.replace(/\\/g, "/").toLowerCase();
+  return norm(path).startsWith(norm(root));
 }

--- a/src/StackTraceGraph.tsx
+++ b/src/StackTraceGraph.tsx
@@ -1,104 +1,140 @@
 /**
- * スタックトレースを 1 つの React Flow グラフとして表示する。
- * - 上から下へ frame 順 (#0 が最上、最深 frame が最下)
- * - クリックで `open_at` (in-project のみ。out-of-project は disabled)
- *
- * 入力はテキストエリア → `parse_stack_trace` (Rust) で frames を取り、
- * このコンポーネントへ渡す。
+ * スタックトレースを 1 つの React Flow グラフとして表示。
+ * - frame 1 つ = `RelationCard` (variant="frame")
+ * - 上から下へ #0 → 最深 frame
+ * - in-project はクリック → `open_at`
+ * - 100 frame を超えたら超過分を捨て、コンテキスト行も短縮
  */
-import { useMemo, useEffect } from "react";
+import { useEffect, useState } from "react";
 import { ReactFlow, Background, Controls, type Node, type Edge } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import { win, type StackFrame } from "./lsp";
+import { fs, type StackFrame } from "./lsp";
+import { RelationCard, ensureCardStyles, type RelationCardData } from "./RelationCard";
 
 interface Props {
   frames: StackFrame[];
 }
 
+const MAX_FRAMES = 100;
+const DEFAULT_SNIPPET_CONTEXT = 5;
+const REDUCED_SNIPPET_CONTEXT = 2;
+const FRAME_HEIGHT = 200;
+
+const nodeTypes = { card: RelationCard };
+
 export function StackTraceGraph({ frames }: Props) {
-  const { nodes, edges } = useMemo<{ nodes: Node[]; edges: Edge[] }>(() => {
-    const nodes: Node[] = [];
-    const edges: Edge[] = [];
-
-    frames.forEach((f, i) => {
-      const id = `f-${i}`;
-      const fname = f.path.split(/[\\/]/).pop() ?? f.path;
-      const label = `#${f.index} ${f.function ?? "<anon>"}\n${fname}:${f.line}`;
-      nodes.push({
-        id,
-        data: { label, path: f.path, line: f.line, inProject: f.in_project },
-        position: { x: 0, y: i * 80 },
-        style: frameStyle(f.in_project),
-        className: f.in_project ? "iter-clickable" : "iter-disabled",
-      });
-      if (i > 0) {
-        edges.push({
-          id: `e-${i}`,
-          source: `f-${i - 1}`,
-          target: id,
-          animated: false,
-          style: { stroke: "#4a7afe" },
-        });
-      }
-    });
-
-    return { nodes, edges };
-  }, [frames]);
+  const [graph, setGraph] = useState<{ nodes: Node[]; edges: Edge[]; trimmed: number }>({
+    nodes: [],
+    edges: [],
+    trimmed: 0,
+  });
 
   useEffect(() => {
-    const id = "iter-graph-style";
-    if (document.getElementById(id)) return;
-    const s = document.createElement("style");
-    s.id = id;
-    s.textContent = `
-      .iter-clickable { cursor: pointer; }
-      .iter-disabled  { cursor: not-allowed; opacity: 0.55; }
-      .react-flow__attribution { display: none; }
-    `;
-    document.head.appendChild(s);
+    ensureCardStyles();
   }, []);
 
-  const onNodeClick = (_: unknown, node: Node) => {
-    const d = node.data as { path?: string; line?: number; inProject?: boolean };
-    if (!d.inProject || !d.path || d.line === undefined) return;
-    // line は 1-based 想定。Monaco は 1-based、LSP は 0-based。
-    // stack-trace は 1-based なので、Monaco 互換のため -1 して渡す
-    void win.openAt(d.path, Math.max(0, d.line - 1), 0, false);
-  };
+  useEffect(() => {
+    if (!frames.length) {
+      setGraph({ nodes: [], edges: [], trimmed: 0 });
+      return;
+    }
+    let cancelled = false;
+    const trimmed = Math.max(0, frames.length - MAX_FRAMES);
+    const used = trimmed > 0 ? frames.slice(0, MAX_FRAMES) : frames;
+    const ctx = used.length > 60 ? REDUCED_SNIPPET_CONTEXT : DEFAULT_SNIPPET_CONTEXT;
+
+    (async () => {
+      const snippets = await Promise.all(
+        used.map((f) =>
+          // stack frame の line は 1-based、Rust 側は 0-based 想定なので -1
+          fs.readSnippet(f.path, Math.max(0, f.line - 1), ctx).catch(() => null),
+        ),
+      );
+      if (cancelled) return;
+
+      const nodes: Node[] = [];
+      const edges: Edge[] = [];
+
+      used.forEach((f, i) => {
+        const id = `frame-${i}`;
+        const snip = snippets[i];
+        const data: RelationCardData = {
+          variant: "frame",
+          symbol: f.function ?? "<anon>",
+          path: f.path,
+          line: Math.max(0, f.line - 1),
+          snippet: snip?.lines ?? [],
+          snippetStart: snip?.start_line ?? Math.max(0, f.line - 1),
+          inProject: f.in_project,
+          badge: `#${f.index}`,
+        };
+        nodes.push({
+          id,
+          type: "card",
+          data,
+          position: { x: 0, y: i * FRAME_HEIGHT },
+          draggable: true,
+        });
+        if (i > 0) {
+          edges.push({
+            id: `e-${i}`,
+            source: `frame-${i - 1}`,
+            target: id,
+            style: { stroke: "#9a8cff" },
+          });
+        }
+      });
+
+      setGraph({ nodes, edges, trimmed });
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [frames]);
 
   if (!frames.length) {
     return (
       <div style={{ padding: "1rem", color: "#6b7383", fontSize: "0.85rem" }}>
-        スタックトレースをパースすると frame グラフが出ます
+        スタックトレースを貼り付けてグラフ化すると frame カードが出ます
       </div>
     );
   }
 
   return (
-    <ReactFlow
-      nodes={nodes}
-      edges={edges}
-      onNodeClick={onNodeClick}
-      fitView
-      proOptions={{ hideAttribution: true }}
-      colorMode="dark"
-    >
-      <Background color="#222831" gap={16} />
-      <Controls showInteractive={false} />
-    </ReactFlow>
+    <div style={{ position: "relative", height: "100%" }}>
+      {graph.trimmed > 0 && (
+        <div
+          style={{
+            position: "absolute",
+            top: 6,
+            left: 6,
+            zIndex: 10,
+            background: "rgba(239, 197, 106, 0.15)",
+            border: "1px solid #efc56a",
+            color: "#efc56a",
+            padding: "2px 8px",
+            borderRadius: 3,
+            fontSize: 11,
+            fontFamily: "ui-monospace, Consolas, monospace",
+          }}
+        >
+          表示上限 {MAX_FRAMES} ({graph.trimmed} frame 省略)
+        </div>
+      )}
+      <ReactFlow
+        nodes={graph.nodes}
+        edges={graph.edges}
+        nodeTypes={nodeTypes}
+        fitView
+        proOptions={{ hideAttribution: true }}
+        colorMode="dark"
+        minZoom={0.2}
+        maxZoom={1.5}
+      >
+        <Background color="#222831" gap={16} />
+        <Controls showInteractive={false} />
+      </ReactFlow>
+    </div>
   );
-}
-
-function frameStyle(inProject: boolean) {
-  return {
-    background: "#11141a",
-    color: inProject ? "#e6e8ee" : "#6b7383",
-    border: `1px solid ${inProject ? "#4a7afe" : "#3a3f4a"}`,
-    borderRadius: 4,
-    padding: "6px 10px",
-    fontSize: 11,
-    fontFamily: "ui-monospace, Consolas, monospace",
-    whiteSpace: "pre-line" as const,
-    minWidth: 220,
-  };
 }

--- a/src/StackTraceGraph.tsx
+++ b/src/StackTraceGraph.tsx
@@ -1,0 +1,104 @@
+/**
+ * スタックトレースを 1 つの React Flow グラフとして表示する。
+ * - 上から下へ frame 順 (#0 が最上、最深 frame が最下)
+ * - クリックで `open_at` (in-project のみ。out-of-project は disabled)
+ *
+ * 入力はテキストエリア → `parse_stack_trace` (Rust) で frames を取り、
+ * このコンポーネントへ渡す。
+ */
+import { useMemo, useEffect } from "react";
+import { ReactFlow, Background, Controls, type Node, type Edge } from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import { win, type StackFrame } from "./lsp";
+
+interface Props {
+  frames: StackFrame[];
+}
+
+export function StackTraceGraph({ frames }: Props) {
+  const { nodes, edges } = useMemo<{ nodes: Node[]; edges: Edge[] }>(() => {
+    const nodes: Node[] = [];
+    const edges: Edge[] = [];
+
+    frames.forEach((f, i) => {
+      const id = `f-${i}`;
+      const fname = f.path.split(/[\\/]/).pop() ?? f.path;
+      const label = `#${f.index} ${f.function ?? "<anon>"}\n${fname}:${f.line}`;
+      nodes.push({
+        id,
+        data: { label, path: f.path, line: f.line, inProject: f.in_project },
+        position: { x: 0, y: i * 80 },
+        style: frameStyle(f.in_project),
+        className: f.in_project ? "iter-clickable" : "iter-disabled",
+      });
+      if (i > 0) {
+        edges.push({
+          id: `e-${i}`,
+          source: `f-${i - 1}`,
+          target: id,
+          animated: false,
+          style: { stroke: "#4a7afe" },
+        });
+      }
+    });
+
+    return { nodes, edges };
+  }, [frames]);
+
+  useEffect(() => {
+    const id = "iter-graph-style";
+    if (document.getElementById(id)) return;
+    const s = document.createElement("style");
+    s.id = id;
+    s.textContent = `
+      .iter-clickable { cursor: pointer; }
+      .iter-disabled  { cursor: not-allowed; opacity: 0.55; }
+      .react-flow__attribution { display: none; }
+    `;
+    document.head.appendChild(s);
+  }, []);
+
+  const onNodeClick = (_: unknown, node: Node) => {
+    const d = node.data as { path?: string; line?: number; inProject?: boolean };
+    if (!d.inProject || !d.path || d.line === undefined) return;
+    // line は 1-based 想定。Monaco は 1-based、LSP は 0-based。
+    // stack-trace は 1-based なので、Monaco 互換のため -1 して渡す
+    void win.openAt(d.path, Math.max(0, d.line - 1), 0, false);
+  };
+
+  if (!frames.length) {
+    return (
+      <div style={{ padding: "1rem", color: "#6b7383", fontSize: "0.85rem" }}>
+        スタックトレースをパースすると frame グラフが出ます
+      </div>
+    );
+  }
+
+  return (
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      onNodeClick={onNodeClick}
+      fitView
+      proOptions={{ hideAttribution: true }}
+      colorMode="dark"
+    >
+      <Background color="#222831" gap={16} />
+      <Controls showInteractive={false} />
+    </ReactFlow>
+  );
+}
+
+function frameStyle(inProject: boolean) {
+  return {
+    background: "#11141a",
+    color: inProject ? "#e6e8ee" : "#6b7383",
+    border: `1px solid ${inProject ? "#4a7afe" : "#3a3f4a"}`,
+    borderRadius: 4,
+    padding: "6px 10px",
+    fontSize: 11,
+    fontFamily: "ui-monospace, Consolas, monospace",
+    whiteSpace: "pre-line" as const,
+    minWidth: 220,
+  };
+}

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -1,0 +1,113 @@
+import { invoke } from "@tauri-apps/api/core";
+
+/** Rust 側 `lsp_types::Uri` を文字列としてだけ扱う (ts では生 URL) */
+export interface LspPosition {
+  line: number;
+  character: number;
+}
+
+export interface LspRange {
+  start: LspPosition;
+  end: LspPosition;
+}
+
+export interface LspLocation {
+  /** RFC3986 URI string. file:// scheme 想定 */
+  uri: string;
+  range: LspRange;
+}
+
+export interface CallHierarchyItem {
+  name: string;
+  kind: number;
+  detail?: string;
+  uri: string;
+  range: LspRange;
+  selectionRange: LspRange;
+}
+
+export interface CallHierarchyIncomingCall {
+  from: CallHierarchyItem;
+  fromRanges: LspRange[];
+}
+
+export interface CallHierarchyOutgoingCall {
+  to: CallHierarchyItem;
+  fromRanges: LspRange[];
+}
+
+export interface CallHierarchyResult {
+  items: CallHierarchyItem[];
+  incoming: CallHierarchyIncomingCall[];
+  outgoing: CallHierarchyOutgoingCall[];
+}
+
+export interface StackFrame {
+  index: number;
+  function: string | null;
+  path: string;
+  line: number;
+  column: number | null;
+  in_project: boolean;
+}
+
+export const lsp = {
+  async openProject(root: string): Promise<void> {
+    await invoke("lsp_open_project", { root });
+  },
+  async openFile(path: string, text: string): Promise<void> {
+    await invoke("lsp_open_file", { path, text });
+  },
+  async callHierarchy(
+    path: string,
+    line: number,
+    character: number,
+  ): Promise<CallHierarchyResult> {
+    return invoke<CallHierarchyResult>("lsp_call_hierarchy", {
+      path,
+      line,
+      character,
+    });
+  },
+  async references(
+    path: string,
+    line: number,
+    character: number,
+  ): Promise<LspLocation[]> {
+    return invoke<LspLocation[]>("lsp_references", { path, line, character });
+  },
+  async parseStackTrace(text: string, projectRoot?: string): Promise<StackFrame[]> {
+    return invoke<StackFrame[]>("parse_stack_trace", {
+      text,
+      projectRoot: projectRoot ?? null,
+    });
+  },
+};
+
+export const win = {
+  async openFileWindow(path: string): Promise<void> {
+    await invoke("open_file_window", { path });
+  },
+  async openAt(
+    path: string,
+    line: number,
+    column?: number,
+    followDefinition?: boolean,
+  ): Promise<void> {
+    await invoke("open_at", {
+      path,
+      line,
+      column: column ?? null,
+      followDefinition: followDefinition ?? null,
+    });
+  },
+};
+
+/** uri から OS パスへの変換 (`file:///c:/foo` → `c:/foo`)。Windows / Unix 両対応。 */
+export function uriToPath(uri: string): string {
+  if (!uri.startsWith("file://")) return uri;
+  const after = decodeURIComponent(uri.slice("file://".length));
+  // Windows: `/c:/foo` → `c:/foo`
+  if (/^\/[A-Za-z]:/.test(after)) return after.slice(1);
+  return after;
+}

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -101,6 +101,21 @@ export const win = {
       followDefinition: followDefinition ?? null,
     });
   },
+  async closeOthers(exceptLabel: string): Promise<number> {
+    return invoke<number>("close_other_windows", { exceptLabel });
+  },
+};
+
+export interface Snippet {
+  start_line: number;
+  target_line: number;
+  lines: string[];
+}
+
+export const fs = {
+  async readSnippet(path: string, line: number, context: number): Promise<Snippet> {
+    return invoke<Snippet>("read_snippet", { path, line, context });
+  },
 };
 
 /** uri から OS パスへの変換 (`file:///c:/foo` → `c:/foo`)。Windows / Unix 両対応。 */


### PR DESCRIPTION
## Summary

Phase 2 機能と途中追加された 4 件の要望を 1 PR に集約。

## 追加機能

| # | 機能 | 実装 |
|---|---|---|
| 1 | clangd LSP 統合 | `compile_commands.json` 検知/自動生成 → clangd subprocess + JSON-RPC |
| 2 | 関連グラフ | React Flow で caller/callee/refs を Monaco の右パネルに、project 外は disabled |
| 3 | file+line で起動して宣言追跡 | `open_at` コマンド + `iter://open-at` イベント |
| 4 | スタックトレース → グラフ | GCC/Clang/GDB/V8/Python/Rust 対応 best-effort パーサ + 縦 1 列グラフ |
| 5 | プロジェクト構造キャッシュ | `<config_dir>/iter/projects/<hash>.json`、root mtime で fresh 判定、↻ ボタンで明示再走査 |
| 6 | Ctrl+ホイール拡大縮小 | Monaco `mouseWheelZoom: true` |

## 使った OSS
- **Monaco Editor** (Apache 2.0)
- **React Flow / @xyflow/react** (MIT)
- **clangd** (LSP サーバ。subprocess として外部 PATH から起動、バンドル無し)
- **lsp-types** Rust crate

## アーキテクチャ

```
ControlPanel ─┬─ [プロジェクト選択] ─→ detect_project (cache hit ? 即返 : 走査+save)
              ├─ [LSP: ready] ───────→ lsp_open_project (compile_commands → clangd spawn)
              ├─ [チェックボックス] ──→ emit iter://relations-changed
              └─ [スタックトレース] ──→ parse_stack_trace → StackTraceGraph

FileWindow ───┬─ [Monaco mount] ─────→ lsp_open_file (didOpen)
              ├─ [カーソル移動 250ms] → lsp_call_hierarchy + lsp_references → RelationGraph
              ├─ [ノードクリック] ───→ open_at (該当行ジャンプ)
              └─ [iter://open-at] ──→ revealLineInCenter + setPosition
```

## ビルド検証

- `npx tsc -b` ✓ 0 errors
- `npx vite build` ✓ 214 modules
- `cargo check` ✓ 0 errors / 0 warnings

## 動作前提

- clangd を PATH に置く ([releases](https://github.com/clangd/clangd/releases))
- CMake プロジェクトの場合、cmake コマンドが PATH にあると `compile_commands.json` を自動生成
- vcxproj (MSVC) は `compile_commands.json` を別途用意するか、Phase 2.5 で対応予定

## Test plan

- [ ] `npm run tauri dev` 起動 → Control Panel が出る
- [ ] CMake プロジェクトを開く → "LSP: ready" バッジが緑
- [ ] 2 回目以降の同じプロジェクト → "cached" バッジ + 即時表示、↻ で再走査
- [ ] ファイルを開いて関数名にカーソル → 右パネルに caller/callee がノードで出る
- [ ] caller ノードをクリック → 該当ファイルの該当行が開く
- [ ] チェックボックスで callees を OFF → 右パネルから消える
- [ ] スタックトレース貼り付け → 「グラフ化」→ frame ノード縦並び、in-project クリックで開く
- [ ] Ctrl+ホイールで Monaco が拡大縮小

🤖 Generated with [Claude Code](https://claude.com/claude-code)