### PR TITLE
docs: NOTICE と THIRD_PARTY_LICENSES

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,35 @@
+Iter
+Copyright (c) 2026 LUDIARS
+
+Iter is licensed under the MIT License (see LICENSE).
+
+This product depends on third-party software, some of which is distributed
+under the Apache License 2.0. The Apache 2.0 attribution notices for those
+dependencies are reproduced in THIRD_PARTY_LICENSES.md.
+
+In particular, this product:
+
+  * Bundles the Monaco Editor (https://github.com/microsoft/monaco-editor),
+    Copyright (c) Microsoft Corporation, licensed under the MIT License.
+
+  * Builds against the Tauri framework
+    (https://github.com/tauri-apps/tauri),
+    Copyright (c) The Tauri Programme within The Commons Conservancy,
+    licensed under either Apache License 2.0 or MIT at the user's option.
+
+  * Bundles React Flow / @xyflow/react
+    (https://github.com/xyflow/xyflow),
+    Copyright (c) the xyflow team, licensed under the MIT License.
+
+  * Bundles React (https://github.com/facebook/react),
+    Copyright (c) Meta Platforms, Inc. and affiliates, licensed under the
+    MIT License.
+
+  * Optionally invokes clangd (https://github.com/clangd/clangd) as an
+    external subprocess at runtime. clangd is part of the LLVM Project
+    and is licensed under the Apache License 2.0 with LLVM Exceptions.
+    clangd binaries are NOT redistributed by Iter; the user installs
+    clangd separately.
+
+For the full text of each license and the per-package attribution, see
+THIRD_PARTY_LICENSES.md.

--- a/README.md
+++ b/README.md
@@ -54,4 +54,6 @@ npm run tauri dev
 
 ## ライセンス
 
-LICENSE 参照。
+- Iter 本体: MIT (詳細は [LICENSE](LICENSE))
+- 依存ライブラリの帰属表示: [NOTICE](NOTICE)
+- 第三者ライセンス目録: [THIRD_PARTY_LICENSES.md](THIRD_PARTY_LICENSES.md)

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,69 @@
+# Third-Party Licenses
+
+Iter is licensed under the MIT License (see [LICENSE](LICENSE)).
+
+This document lists the third-party software bundled with, or required at
+runtime by, Iter, together with the SPDX identifier of each license and a
+link to its canonical license text. Where a package is dual-licensed,
+Iter relies on it under one of the listed licenses; the user may rely on
+either.
+
+For Apache-2.0 packages, see [NOTICE](NOTICE) for the attribution notice
+required by section 4(d) of the Apache 2.0 license.
+
+## Frontend (npm)
+
+| Package | Version range | License (SPDX) | Source |
+|---|---|---|---|
+| `monaco-editor` | ^0.52 | MIT | <https://github.com/microsoft/monaco-editor/blob/main/LICENSE.md> |
+| `@monaco-editor/react` | ^4.7 | MIT | <https://github.com/suren-atoyan/monaco-react/blob/master/LICENSE> |
+| `@xyflow/react` (React Flow) | ^12.3 | MIT | <https://github.com/xyflow/xyflow/blob/main/LICENSE> |
+| `react`, `react-dom` | ^19 | MIT | <https://github.com/facebook/react/blob/main/LICENSE> |
+| `@tauri-apps/api` | ^2.1 | Apache-2.0 OR MIT | <https://github.com/tauri-apps/tauri/blob/dev/LICENSE_MIT> |
+| `@tauri-apps/cli` | ^2.1 | Apache-2.0 OR MIT | <https://github.com/tauri-apps/tauri/blob/dev/LICENSE_MIT> |
+| `@tauri-apps/plugin-dialog` | ^2.0 | Apache-2.0 OR MIT | <https://github.com/tauri-apps/plugins-workspace> |
+| `@tauri-apps/plugin-fs` | ^2.0 | Apache-2.0 OR MIT | <https://github.com/tauri-apps/plugins-workspace> |
+| `@vitejs/plugin-react` | ^4 | MIT | <https://github.com/vitejs/vite-plugin-react/blob/main/LICENSE> |
+| `vite` | ^6 | MIT | <https://github.com/vitejs/vite/blob/main/LICENSE> |
+| `vitest` | ^3 | MIT | <https://github.com/vitest-dev/vitest/blob/main/LICENSE> |
+| `typescript` | ^5.7 | Apache-2.0 | <https://github.com/microsoft/TypeScript/blob/main/LICENSE.txt> |
+| `@types/*` | (transitive) | MIT | DefinitelyTyped repository |
+
+## Backend (cargo)
+
+| Crate | Version range | License (SPDX) | Source |
+|---|---|---|---|
+| `tauri` | 2 | Apache-2.0 OR MIT | <https://github.com/tauri-apps/tauri> |
+| `tauri-build` | 2 | Apache-2.0 OR MIT | <https://github.com/tauri-apps/tauri> |
+| `tauri-plugin-dialog` | 2 | Apache-2.0 OR MIT | <https://github.com/tauri-apps/plugins-workspace> |
+| `tauri-plugin-fs` | 2 | Apache-2.0 OR MIT | <https://github.com/tauri-apps/plugins-workspace> |
+| `serde`, `serde_json` | 1 | Apache-2.0 OR MIT | <https://github.com/serde-rs/serde> |
+| `tokio` | 1 | MIT | <https://github.com/tokio-rs/tokio/blob/master/LICENSE> |
+| `thiserror` | 2 | Apache-2.0 OR MIT | <https://github.com/dtolnay/thiserror> |
+| `lsp-types` | 0.97 | MIT | <https://github.com/gluon-lang/lsp-types/blob/master/LICENSE> |
+| `url` | 2 | Apache-2.0 OR MIT | <https://github.com/servo/rust-url> |
+| `which` | 7 | MIT | <https://github.com/harryfei/which-rs/blob/master/LICENSE.txt> |
+
+(Transitive crate dependencies inherit the licenses declared in their
+respective `Cargo.toml` and the upstream crate registry. A full
+machine-readable inventory can be regenerated with `cargo about generate`
+or `cargo deny check licenses`.)
+
+## Runtime tooling (not bundled)
+
+| Tool | License (SPDX) | Source |
+|---|---|---|
+| **clangd** (LSP server, invoked as a subprocess when present in `PATH`) | Apache-2.0 WITH LLVM-exception | <https://github.com/clangd/clangd> |
+| **CMake** (used to generate `compile_commands.json` when present in `PATH`) | BSD-3-Clause | <https://gitlab.kitware.com/cmake/cmake/-/blob/master/Copyright.txt> |
+
+Iter neither redistributes nor links statically against clangd or CMake.
+Users install them separately and Iter shells out to whichever copy is
+on `PATH`.
+
+## License texts
+
+Full canonical license texts are not duplicated here to keep this file
+maintainable; follow the "Source" links above. When distributing Iter
+binaries, the per-package `LICENSE` files installed under `node_modules/`
+and the cargo registry cache satisfy the "include a copy of the License"
+requirement of Apache 2.0 section 4(a).


### PR DESCRIPTION
## Summary

Issue #9 を解決。Apache 2.0 license section 4(d) の attribution 要件を満たすため、依存ライブラリの帰属表示を `NOTICE` ファイルに、第三者ライセンス目録を `THIRD_PARTY_LICENSES.md` に整備。

## 追加

- **NOTICE**: Iter 本体の copyright + 主要 Apache-2.0 / MIT 依存 (Tauri, Monaco, React, React Flow) と runtime 依存の clangd (Apache-2.0 WITH LLVM-exception、ユーザ側でインストール) の帰属
- **THIRD_PARTY_LICENSES.md**: frontend (npm) / backend (cargo) / runtime tooling それぞれを SPDX identifier + 公式 license source link の表で整理。完全な license 全文は per-package `LICENSE` ファイルに委ねる方針 (機械可読な完全目録は `cargo about generate` で再生成できる旨を明記)
- **README.md**: 上記 2 ファイルへのリンクを追加

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)