### PR TITLE
sre+sec: clangd watchdog + fs:scope tightening + stderr piped

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Capabilities granted to all Iter windows in MVP. file scope is the entire OS — Phase 2 で プロジェクト root scoping に絞る。",
+  "description": "Capabilities granted to all Iter windows. fs scope is restricted to user-data directories at startup; project roots outside these are added at runtime by detect_project / lsp_open_project via fs_scope().allow_directory().",
   "windows": ["control-panel", "file-*"],
   "permissions": [
     "core:default",
@@ -18,7 +18,15 @@
     {
       "identifier": "fs:scope",
       "allow": [
-        { "path": "**" }
+        { "path": "$HOME/**" },
+        { "path": "$APPCONFIG/**" },
+        { "path": "$APPDATA/**" },
+        { "path": "$APPLOCALDATA/**" }
+      ],
+      "deny": [
+        { "path": "$HOME/.ssh/**" },
+        { "path": "$HOME/.aws/**" },
+        { "path": "$HOME/.gnupg/**" }
       ]
     }
   ]

--- a/src-tauri/src/lsp.rs
+++ b/src-tauri/src/lsp.rs
@@ -3,13 +3,17 @@
 //! - stdin/stdout で JSON-RPC、Content-Length ヘッダフレーミング
 //! - 1 プロジェクト = 1 clangd プロセス、`AppState` 配下に Arc<Mutex<Option<Client>>> で保持
 //! - フロントが叩く Tauri コマンドからは `Client::*` を await で呼ぶ
+//! - clangd プロセスを wait task で監視し、死亡時に `iter://lsp-down` を emit。
+//!   pending request は即時 error で drain し、`is_dead` を立てて以降の request も拒否
+//! - stderr は piped で受け、直近 STDERR_RING_CAP 行を保持。死亡通知に同梱
 //!
 //! Phase 2 の MVP では call hierarchy / references / definition の 3 系統だけ。
 //! semanticTokens / inlayHint / formatter 等は今回スコープ外。
 
+use std::collections::{HashMap, VecDeque};
 use std::path::Path;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
 
 use lsp_types::{
     CallHierarchyIncomingCall, CallHierarchyItem, CallHierarchyOutgoingCall, ClientCapabilities,
@@ -17,17 +21,19 @@ use lsp_types::{
     ReferenceContext, ReferenceParams, TextDocumentIdentifier, TextDocumentItem,
     TextDocumentPositionParams, Uri, WorkDoneProgressParams, WorkspaceFolder,
 };
-use std::str::FromStr;
 use serde_json::{Value, json};
-use std::collections::HashMap;
-use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
-use tokio::process::{Child, ChildStdin, Command};
+use std::str::FromStr;
+use tauri::Emitter;
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{ChildStdin, Command};
 use tokio::sync::{Mutex, oneshot};
 
 #[derive(Debug, thiserror::Error)]
 pub enum LspError {
     #[error("clangd not found in PATH")]
     ClangdNotFound,
+    #[error("clangd exited unexpectedly: {0}")]
+    Dead(String),
     #[error("io: {0}")]
     Io(String),
     #[error("rpc: {0}")]
@@ -42,16 +48,23 @@ impl From<std::io::Error> for LspError {
 
 type Pending = Arc<Mutex<HashMap<i64, oneshot::Sender<Result<Value, String>>>>>;
 
+const STDERR_RING_CAP: usize = 100;
+
 pub struct ClangdClient {
-    _process: Child,
     stdin: Mutex<ChildStdin>,
     next_id: AtomicI64,
     pending: Pending,
+    is_dead: Arc<AtomicBool>,
 }
 
 impl ClangdClient {
     /// clangd を起動し、initialize / initialized を完了するまでブロックする。
-    pub async fn spawn(project_root: &Path, compile_commands_dir: &Path) -> Result<Self, LspError> {
+    /// `app` は wait task が `iter://lsp-down` イベントを emit するために使う。
+    pub async fn spawn(
+        project_root: &Path,
+        compile_commands_dir: &Path,
+        app: tauri::AppHandle,
+    ) -> Result<Self, LspError> {
         let clangd = which::which("clangd").map_err(|_| LspError::ClangdNotFound)?;
 
         let mut child = Command::new(clangd)
@@ -64,16 +77,33 @@ impl ClangdClient {
             .arg("--header-insertion=never")
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
             .spawn()?;
 
         let stdin = child.stdin.take().expect("stdin captured");
         let stdout = child.stdout.take().expect("stdout captured");
+        let stderr = child.stderr.take().expect("stderr captured");
 
         let pending: Pending = Arc::new(Mutex::new(HashMap::new()));
-        let pending_for_reader = pending.clone();
+        let stderr_ring: Arc<Mutex<VecDeque<String>>> =
+            Arc::new(Mutex::new(VecDeque::with_capacity(STDERR_RING_CAP)));
+        let is_dead = Arc::new(AtomicBool::new(false));
 
-        // stdout reader タスク: 受信 → pending の oneshot へ流す
+        // stderr reader: 改行ごとにリングへ追加 (上限超過時は前から drop)
+        let stderr_ring_for_reader = stderr_ring.clone();
+        tokio::spawn(async move {
+            let mut lines = BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                let mut b = stderr_ring_for_reader.lock().await;
+                if b.len() >= STDERR_RING_CAP {
+                    b.pop_front();
+                }
+                b.push_back(line);
+            }
+        });
+
+        // stdout reader: 受信メッセージを pending の oneshot へ流す
+        let pending_for_reader = pending.clone();
         tokio::spawn(async move {
             let mut reader = BufReader::new(stdout);
             loop {
@@ -99,16 +129,59 @@ impl ClangdClient {
             }
         });
 
+        // wait task: child の終了を待ち、死亡時に状態を更新 + フロントへ通知
+        let pending_for_wait = pending.clone();
+        let stderr_ring_for_wait = stderr_ring.clone();
+        let is_dead_for_wait = is_dead.clone();
+        let app_for_wait = app.clone();
+        tokio::spawn(async move {
+            let mut child = child;
+            let exit = child.wait().await;
+            is_dead_for_wait.store(true, Ordering::SeqCst);
+
+            let exit_desc = match &exit {
+                Ok(s) => match s.code() {
+                    Some(c) => format!("exit {c}"),
+                    None => "killed by signal".to_string(),
+                },
+                Err(e) => format!("wait failed: {e}"),
+            };
+            let recent: Vec<String> = stderr_ring_for_wait.lock().await.iter().cloned().collect();
+
+            // フロントに通知。emit 失敗 (window 全閉等) は致命ではない
+            let _ = app_for_wait.emit(
+                "iter://lsp-down",
+                json!({
+                    "reason": exit_desc,
+                    "stderr": recent,
+                }),
+            );
+
+            // pending を全部 error で drain (フロント側 hang 防止)
+            let mut p = pending_for_wait.lock().await;
+            for (_id, tx) in p.drain() {
+                let _ = tx.send(Err(format!("clangd exited: {exit_desc}")));
+            }
+        });
+
+        // stderr_ring は reader task と wait task が Arc で持ち合うので Self には保持しない
+        drop(stderr_ring);
+
         let client = Self {
-            _process: child,
             stdin: Mutex::new(stdin),
             next_id: AtomicI64::new(1),
             pending,
+            is_dead,
         };
 
         client.initialize(project_root).await?;
         client.initialized().await?;
         Ok(client)
+    }
+
+    /// clangd が既に死んでいるか。死亡監視 task が wait().await から返ったら true。
+    pub fn is_dead(&self) -> bool {
+        self.is_dead.load(Ordering::SeqCst)
     }
 
     async fn initialize(&self, project_root: &Path) -> Result<(), LspError> {
@@ -226,6 +299,9 @@ impl ClangdClient {
     }
 
     async fn request(&self, method: &str, params: Value) -> Result<Value, LspError> {
+        if self.is_dead() {
+            return Err(LspError::Dead("clangd is not running".to_string()));
+        }
         let id = self.next_id.fetch_add(1, Ordering::SeqCst);
         let (tx, rx) = oneshot::channel();
         self.pending.lock().await.insert(id, tx);
@@ -246,6 +322,9 @@ impl ClangdClient {
     }
 
     async fn notify(&self, method: &str, params: Value) -> Result<(), LspError> {
+        if self.is_dead() {
+            return Err(LspError::Dead("clangd is not running".to_string()));
+        }
         let msg = json!({
             "jsonrpc": "2.0",
             "method": method,

--- a/src-tauri/src/lsp_commands.rs
+++ b/src-tauri/src/lsp_commands.rs
@@ -6,7 +6,7 @@
 //!
 //! Phase 2 MVP では同時に 1 プロジェクトしか開けない (シングルトン)。
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -14,6 +14,7 @@ use lsp_types::{
     CallHierarchyIncomingCall, CallHierarchyItem, CallHierarchyOutgoingCall, Location, Uri,
 };
 use serde::Serialize;
+use tauri_plugin_fs::FsExt;
 use tokio::sync::Mutex;
 
 use crate::compile_db;
@@ -26,16 +27,20 @@ pub struct LspState {
 }
 
 /// プロジェクトを開いて clangd を起動する。compile_commands.json を必要なら生成。
+/// `app` は ClangdClient の wait task と動的 fs scope 拡張に使う。
 #[tauri::command]
 pub async fn lsp_open_project(
+    app: tauri::AppHandle,
     state: tauri::State<'_, LspState>,
     root: String,
 ) -> Result<(), String> {
     let root_path = PathBuf::from(&root);
+    expand_fs_scope(&app, &root_path);
+
     let cc = compile_db::ensure_compile_commands(&root_path)?;
     let cc_dir = cc.parent().map(PathBuf::from).unwrap_or(root_path.clone());
 
-    let client = ClangdClient::spawn(&root_path, &cc_dir)
+    let client = ClangdClient::spawn(&root_path, &cc_dir, app.clone())
         .await
         .map_err(|e| e.to_string())?;
     let arc = Arc::new(client);
@@ -43,6 +48,23 @@ pub async fn lsp_open_project(
     *state.client.lock().await = Some(arc);
     *state.project_root.lock().await = Some(root_path);
     Ok(())
+}
+
+/// `tauri-plugin-fs` の scope に project root を再帰許可で追加する。
+///
+/// 起動時の static scope は `$HOME` などユーザ data dir に絞っていて、それ以外
+/// (D:/projects/foo 等) はランタイムでこの関数が拡張する。失敗しても致命では
+/// なく warn のみ — その場合 frontend の readTextFile が拒否されてユーザに
+/// 見えるエラーになる。
+pub fn expand_fs_scope(app: &tauri::AppHandle, root: &Path) {
+    let scope = app.fs_scope();
+    if let Err(e) = scope.allow_directory(root, true) {
+        eprintln!(
+            "[fs-scope] failed to expand scope to {}: {}",
+            root.display(),
+            e
+        );
+    }
 }
 
 #[tauri::command]

--- a/src-tauri/src/project.rs
+++ b/src-tauri/src/project.rs
@@ -70,7 +70,10 @@ const SKIP_DIR_NAMES: &[&str] = &[
 const MAX_DEPTH: usize = 8;
 
 #[tauri::command]
-pub fn detect_project(root: String) -> Result<ProjectInfo, ProjectError> {
+pub fn detect_project(
+    app: tauri::AppHandle,
+    root: String,
+) -> Result<ProjectInfo, ProjectError> {
     let root_path = PathBuf::from(&root);
     if !root_path.exists() {
         return Err(ProjectError::NotFound(root));
@@ -78,6 +81,10 @@ pub fn detect_project(root: String) -> Result<ProjectInfo, ProjectError> {
     if !root_path.is_dir() {
         return Err(ProjectError::NotADirectory(root));
     }
+
+    // ユーザが選んだ project root を fs scope に動的追加。
+    // 静的 scope は $HOME 等に絞っていて、それ外の root はここで許可される。
+    crate::lsp_commands::expand_fs_scope(&app, &root_path);
 
     // キャッシュヒット (root mtime 一致) なら即返す
     if let Some(mut cached) = cache::try_load::<ProjectInfo>(&root_path) {
@@ -93,11 +100,15 @@ pub fn detect_project(root: String) -> Result<ProjectInfo, ProjectError> {
 
 /// 明示再走査 (キャッシュを破棄してから走査)。
 #[tauri::command]
-pub fn refresh_project(root: String) -> Result<ProjectInfo, ProjectError> {
+pub fn refresh_project(
+    app: tauri::AppHandle,
+    root: String,
+) -> Result<ProjectInfo, ProjectError> {
     let root_path = PathBuf::from(&root);
     if !root_path.exists() {
         return Err(ProjectError::NotFound(root));
     }
+    crate::lsp_commands::expand_fs_scope(&app, &root_path);
     cache::invalidate(&root_path);
     let info = walk_root(&root_path)?;
     let _ = cache::save(&root_path, &info);


### PR DESCRIPTION
## Summary

Issue #7 (clangd 死亡監視なし) + #8 (fs:scope=\`**\` で全 OS パス) + 中優先 M4 (lsp stderr Stdio::null) を一括解決。

## clangd watchdog (#7 / M4)

- \`ClangdClient::spawn\` が \`AppHandle\` を受け取るように
- stderr を \`Stdio::piped\` にして reader task で直近 100 行をリングバッファ保持
- wait task を 1 本起動: \`child.wait()\` を await し、終了時に:
  - \`is_dead\` フラグを SeqCst で立てる
  - \`iter://lsp-down\` イベントを \`{reason, stderr[]}\` payload で emit
  - pending HashMap を全部 error で drain (フロント側の永久 hang 防止)
- \`request\`/\`notify\` 入口で \`is_dead\` を見て即時 \`LspError::Dead\` を返す
- \`_process: Child\` を Self に保持するのをやめ、wait task が child を所有 (drop 順序を簡素化)

## fs:scope tightening (#8)

- \`capabilities/default.json\` の static scope を \`**\` から:
  - allow: \`\$HOME/**\`, \`\$APPCONFIG/**\`, \`\$APPDATA/**\`, \`\$APPLOCALDATA/**\`
  - deny: \`\$HOME/.ssh/**\`, \`\$HOME/.aws/**\`, \`\$HOME/.gnupg/**\`
- \`detect_project\`/\`refresh_project\`/\`lsp_open_project\` が \`AppHandle\` を受け取り、\`fs_scope().allow_directory(root, true)\` で project root を動的に scope に追加 — \`\$HOME\` 外 (\`D:/foo\` 等) もユーザが選べば許可される

## 検証

- \`cargo check --all-targets\` → 0 errors / 0 warnings
- \`cargo test --all-targets\` → 15/15 passed
- \`npx tsc -b\` → 0 errors

Closes #7, closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)