### PR TITLE
feat(project): C# (.csproj/.sln) と .vcxproj/.sln 検知を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npm run tauri dev
 
 ## MVP (Phase 1) で動くこと
 
-- [x] CMakeLists.txt / *.vcxproj 検知
+- [x] CMakeLists.txt / *.sln / *.vcxproj / *.csproj 検知
 - [x] ファイルツリー表示 (Control Panel)
 - [x] ファイルクリックで個別ウインドウに Monaco Editor で開く
 - [x] 常時表示の検索バー (Ctrl+F でフォーカス + Monaco 上にハイライト)

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1585,6 +1585,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "url",
@@ -3655,6 +3656,19 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 1.1.2+spec-1.1.0",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,5 +25,8 @@ lsp-types = "0.97"
 url = "2"
 which = "7"
 
+[dev-dependencies]
+tempfile = "3"
+
 [features]
 custom-protocol = ["tauri/custom-protocol"]

--- a/src-tauri/src/lsp_commands.rs
+++ b/src-tauri/src/lsp_commands.rs
@@ -162,6 +162,11 @@ fn guess_language_id(path: &str) -> String {
         || lower.ends_with(".hxx")
     {
         "cpp".to_string()
+    } else if lower.ends_with(".cs") {
+        // C# は clangd の対象外。Monaco 側の syntax highlighting 用に "csharp" を返すが、
+        // lsp_open_file が呼ばれるのは clangd 起動成功後のみなので、Csproj/Sln の場合は
+        // そもそもこのパスを通らない (frontend 側でガード)。
+        "csharp".to_string()
     } else {
         "plaintext".to_string()
     }

--- a/src-tauri/src/project.rs
+++ b/src-tauri/src/project.rs
@@ -28,11 +28,17 @@ impl From<std::io::Error> for ProjectError {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum BuildSystem {
+    /// CMakeLists.txt — clangd を直接起動 (compile_commands.json 自動生成)
     Cmake,
+    /// .sln (Visual Studio Solution、複数の .vcxproj/.csproj をぶら下げる)
+    Sln,
+    /// .vcxproj 単独 (MSVC C++ プロジェクト)
     Vcxproj,
+    /// .csproj 単独 (C#) — clangd 対象外
+    Csproj,
     Unknown,
 }
 
@@ -127,23 +133,35 @@ fn walk_root(root_path: &Path) -> Result<ProjectInfo, ProjectError> {
 }
 
 fn detect_build_system(root: &Path) -> BuildSystem {
+    // 優先順位: CMakeLists.txt > .sln > .vcxproj > .csproj > Unknown
+    // .sln は複数の C++/C# project をぶら下げ得るので、単独の .vcxproj/.csproj
+    // より上位に置く。CMakeLists.txt は LSP 統合の主流なので最優先。
     if root.join("CMakeLists.txt").exists() {
         return BuildSystem::Cmake;
     }
-    if let Ok(entries) = std::fs::read_dir(root) {
-        for e in entries.flatten() {
+    let entries: Vec<_> = match std::fs::read_dir(root) {
+        Ok(it) => it.flatten().collect(),
+        Err(_) => return BuildSystem::Unknown,
+    };
+    let has_ext = |ext: &str| {
+        entries.iter().any(|e| {
             let p = e.path();
-            if p.is_file()
+            p.is_file()
                 && p.extension()
                     .and_then(|s| s.to_str())
-                    .map(|s| s.eq_ignore_ascii_case("vcxproj"))
+                    .map(|s| s.eq_ignore_ascii_case(ext))
                     .unwrap_or(false)
-            {
-                return BuildSystem::Vcxproj;
-            }
-        }
+        })
+    };
+    if has_ext("sln") {
+        BuildSystem::Sln
+    } else if has_ext("vcxproj") {
+        BuildSystem::Vcxproj
+    } else if has_ext("csproj") {
+        BuildSystem::Csproj
+    } else {
+        BuildSystem::Unknown
     }
-    BuildSystem::Unknown
 }
 
 fn walk(base: &Path, dir: &Path, depth: usize) -> Result<Vec<FileNode>, ProjectError> {
@@ -191,4 +209,61 @@ fn walk(base: &Path, dir: &Path, depth: usize) -> Result<Vec<FileNode>, ProjectE
         });
     }
     Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn touch(dir: &Path, name: &str) {
+        fs::write(dir.join(name), b"").unwrap();
+    }
+
+    #[test]
+    fn detects_cmake_when_cmakelists_present() {
+        let d = tempdir().unwrap();
+        touch(d.path(), "CMakeLists.txt");
+        touch(d.path(), "Foo.vcxproj"); // CMake が優先される
+        assert_eq!(detect_build_system(d.path()), BuildSystem::Cmake);
+    }
+
+    #[test]
+    fn detects_sln_over_vcxproj_and_csproj() {
+        let d = tempdir().unwrap();
+        touch(d.path(), "Solution.sln");
+        touch(d.path(), "App.vcxproj");
+        touch(d.path(), "Lib.csproj");
+        assert_eq!(detect_build_system(d.path()), BuildSystem::Sln);
+    }
+
+    #[test]
+    fn detects_vcxproj_only() {
+        let d = tempdir().unwrap();
+        touch(d.path(), "App.vcxproj");
+        assert_eq!(detect_build_system(d.path()), BuildSystem::Vcxproj);
+    }
+
+    #[test]
+    fn detects_csproj_only() {
+        let d = tempdir().unwrap();
+        touch(d.path(), "Lib.csproj");
+        assert_eq!(detect_build_system(d.path()), BuildSystem::Csproj);
+    }
+
+    #[test]
+    fn case_insensitive_extensions() {
+        let d = tempdir().unwrap();
+        touch(d.path(), "App.VcxProj");
+        assert_eq!(detect_build_system(d.path()), BuildSystem::Vcxproj);
+    }
+
+    #[test]
+    fn unknown_when_no_markers() {
+        let d = tempdir().unwrap();
+        touch(d.path(), "main.cpp");
+        touch(d.path(), "README.md");
+        assert_eq!(detect_build_system(d.path()), BuildSystem::Unknown);
+    }
 }

--- a/src/ControlPanel.tsx
+++ b/src/ControlPanel.tsx
@@ -7,7 +7,7 @@ import { StackTraceGraph } from "./StackTraceGraph";
 
 interface ProjectInfo {
   root: string;
-  build_system: "cmake" | "vcxproj" | "unknown";
+  build_system: "cmake" | "sln" | "vcxproj" | "csproj" | "unknown";
   files: FileNode[];
   from_cache?: boolean;
 }
@@ -228,7 +228,8 @@ export function ControlPanel() {
             <FileTree nodes={project.files} onOpen={openFile} />
           ) : (
             <div className="cp-tree-empty">
-              「プロジェクトを開く」から CMakeLists.txt があるディレクトリを選択
+              「プロジェクトを開く」から CMakeLists.txt / .sln / .vcxproj / .csproj
+              があるディレクトリを選択
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary

\`BuildSystem\` enum に \`Sln\` と \`Csproj\` を追加し、優先順位を
\`CMakeLists > .sln > .vcxproj > .csproj > Unknown\` に整備。

## バックエンド

- \`BuildSystem\` に \`PartialEq\`/\`Eq\` を derive (テスト比較用)
- \`detect_build_system\` は \`read_dir\` を 1 回だけにして \`has_ext\` closure で各拡張子をチェック。\`.sln\` は複数 project をぶら下げ得るので単独の \`.vcxproj\`/\`.csproj\` より上位
- \`guess_language_id\` に \`.cs\` を追加 (\`csharp\` — Monaco syntax 用、clangd には流れない)
- \`tempfile\` を dev-dependency に追加、\`project::tests\` に検出テストを 6 ケース追加 (cmake/sln/vcxproj/csproj 各検出 + case-insensitive 拡張子 + unknown)

## フロントエンド

- \`ProjectInfo.build_system\` の型 literal に \`"sln"\` / \`"csproj"\` を追加
- ファイルツリー empty 表示の文言も .sln / .csproj に対応

## ドキュメント

- README の Phase 1 チェックリストを「.sln / .vcxproj / .csproj 検知」に更新

## スコープ外 (note)

- \`.sln\`/\`.csproj\`/\`.vcxproj\` 単独の場合、現在は clangd を起動しない (CMake 系のみ)。\`compile_commands.json\` 生成は #15 (PR-E、CMakeLists が無い場合の仮想生成) で対応予定
- C# の関連グラフは clangd の対象外。OmniSharp / csharp-ls 等の別 LSP 統合は将来扱い

## 検証

- \`cargo check --all-targets\` → 0 errors
- \`cargo test --all-targets\` → 21/21 passed (15 stack_trace + 6 project)
- \`npx tsc -b\` → 0 errors
- \`npm test\` → 5/5 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)