### PR TITLE
feat: LSP definitions + restricted CSP + signature-based cache (M1+M2+M3 from #11)

### DIFF
--- a/src-tauri/src/cache.rs
+++ b/src-tauri/src/cache.rs
@@ -5,7 +5,11 @@
 //!   - Linux:   `$XDG_CONFIG_HOME/iter/projects/` (既定 `~/.config/iter/projects/`)
 //!   - macOS:   `~/Library/Application Support/iter/projects/`
 //! - キー: project root の絶対パスを SHA-like (DefaultHasher) でハッシュ
-//! - 妥当性: cache 中の `root_mtime` と現在の root dir mtime を比較。一致なら fresh。
+//! - 妥当性: cache 中の `signature` と現在の project signature を比較。
+//!   signature は root mtime に加えて、 関連ファイル (CMakeLists / *.sln /
+//!   *.vcxproj / *.csproj / *.c / *.cc / *.cpp / *.cxx / *.h / *.hpp / *.hxx)
+//!   の (path, mtime) を hash したもの。 子ディレクトリで source 追加・編集
+//!   されると signature が変わるので cache が正しく invalidate される。
 //!
 //! `detect_project` 側からは `try_load` → ヒットなら即返す、無ければ通常走査して
 //! `save` する流れで使う。
@@ -19,13 +23,32 @@ use std::time::SystemTime;
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CachedProject<T: Serialize> {
     pub root: String,
-    pub root_mtime_secs: u64,
+    /// project signature: root mtime + (path, mtime) hash of relevant files.
+    /// 旧 `root_mtime_secs` は v1 cache の名残で互換のため deserialize 側でも
+    /// 拾うが、 新規保存時はこちらだけ書く。
+    pub signature: u64,
     pub cached_at_secs: u64,
     pub version: u32,
     pub project: T,
 }
 
-const CACHE_VERSION: u32 = 1;
+const CACHE_VERSION: u32 = 2;
+const WALK_MAX_DEPTH: usize = 8;
+/// 走査時に降りないディレクトリ (build 成果物 / VCS / 依存). 名前一致で skip.
+const SKIP_DIRS: &[&str] = &[
+    "node_modules",
+    "target",
+    ".git",
+    ".svn",
+    ".hg",
+    "dist",
+    "build",
+    "out",
+    ".iter",
+    ".cache",
+    ".vs",
+    ".idea",
+];
 
 fn cache_dir() -> Option<PathBuf> {
     dirs_like_config_dir().map(|d| d.join("iter").join("projects"))
@@ -71,6 +94,94 @@ fn root_mtime_secs(root: &Path) -> u64 {
         .unwrap_or(0)
 }
 
+/// 走査対象とみなすファイル拡張子 + 特定ファイル名。 ここに無い拡張子は signature
+/// に寄与しない (= IDE の swap file / log 等の頻繁な変更で cache が無効化しないよう絞る)。
+fn is_relevant_file(path: &Path) -> bool {
+    if let Some(name) = path.file_name().and_then(|s| s.to_str()) {
+        if name.eq_ignore_ascii_case("CMakeLists.txt") {
+            return true;
+        }
+    }
+    let Some(ext) = path
+        .extension()
+        .and_then(|s| s.to_str())
+        .map(|s| s.to_ascii_lowercase())
+    else {
+        return false;
+    };
+    matches!(
+        ext.as_str(),
+        "c" | "cc"
+            | "cpp"
+            | "cxx"
+            | "h"
+            | "hpp"
+            | "hxx"
+            | "sln"
+            | "vcxproj"
+            | "csproj"
+            | "cmake"
+    )
+}
+
+/// project signature を計算する。 走査 relevant な files の (relative-path, mtime)
+/// を hash した値。 順序非依存にするため (path, mtime) のペアを一旦 Vec に集めて
+/// path で sort してから hash。
+///
+/// root 自体の mtime は **意図的に含めない**: README 追加や `node_modules/` 作成
+/// だけでも root inode mtime が変わってしまい、 関係ない変更で cache が
+/// invalidate されるため。 source 系拡張子 (`is_relevant_file`) と
+/// `CMakeLists.txt` の変更のみが signature に効く。
+fn project_signature(root: &Path) -> u64 {
+    let mut entries: Vec<(PathBuf, u64)> = Vec::new();
+    collect_relevant(root, root, 0, &mut entries);
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut h = DefaultHasher::new();
+    for (rel, mtime) in &entries {
+        rel.to_string_lossy().hash(&mut h);
+        mtime.hash(&mut h);
+    }
+    h.finish()
+}
+
+fn collect_relevant(root: &Path, dir: &Path, depth: usize, out: &mut Vec<(PathBuf, u64)>) {
+    if depth > WALK_MAX_DEPTH {
+        return;
+    }
+    let Ok(rd) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in rd.flatten() {
+        let path = entry.path();
+        let Ok(ft) = entry.file_type() else { continue };
+        if ft.is_symlink() {
+            // symlink は cycle 防止で skip
+            continue;
+        }
+        let name = path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("");
+        if ft.is_dir() {
+            if SKIP_DIRS.iter().any(|s| s.eq_ignore_ascii_case(name)) {
+                continue;
+            }
+            collect_relevant(root, &path, depth + 1, out);
+        } else if ft.is_file() && is_relevant_file(&path) {
+            let mtime = entry
+                .metadata()
+                .and_then(|m| m.modified())
+                .ok()
+                .and_then(|t| t.duration_since(SystemTime::UNIX_EPOCH).ok())
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+            let rel = path.strip_prefix(root).unwrap_or(&path).to_path_buf();
+            out.push((rel, mtime));
+        }
+    }
+}
+
 fn now_secs() -> u64 {
     SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
@@ -85,15 +196,15 @@ where
 {
     let path = cache_path(root)?;
     let raw = std::fs::read(&path).ok()?;
-    // ジェネリック T を介すため一度 Value で読んで version + mtime を確認
+    // ジェネリック T を介すため一度 Value で読んで version + signature を確認
     let v: serde_json::Value = serde_json::from_slice(&raw).ok()?;
     let version = v.get("version")?.as_u64()? as u32;
     if version != CACHE_VERSION {
-        return None;
+        return None; // 旧 v1 cache (root_mtime_secs のみ) は破棄
     }
-    let cached_root_mtime = v.get("root_mtime_secs")?.as_u64()?;
-    if cached_root_mtime != root_mtime_secs(root) {
-        return None; // root の更新時刻が変わっていればキャッシュは古い
+    let cached_sig = v.get("signature")?.as_u64()?;
+    if cached_sig != project_signature(root) {
+        return None; // 子ディレクトリも含めた signature が変わっていればキャッシュは古い
     }
     let project_json = v.get("project")?.clone();
     serde_json::from_value::<T>(project_json).ok()
@@ -107,7 +218,7 @@ pub fn save<T: Serialize>(root: &Path, project: &T) -> Result<(), String> {
     }
     let payload = CachedProject {
         root: root.to_string_lossy().into_owned(),
-        root_mtime_secs: root_mtime_secs(root),
+        signature: project_signature(root),
         cached_at_secs: now_secs(),
         version: CACHE_VERSION,
         project,
@@ -121,5 +232,106 @@ pub fn save<T: Serialize>(root: &Path, project: &T) -> Result<(), String> {
 pub fn invalidate(root: &Path) {
     if let Some(p) = cache_path(root) {
         let _ = std::fs::remove_file(p);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::thread::sleep;
+    use std::time::Duration;
+
+    /// fs::metadata の mtime 反映を待つための短い sleep。
+    /// Windows は mtime resolution が比較的粗いので余裕を取る。
+    fn wait_mtime_tick() {
+        sleep(Duration::from_millis(1100));
+    }
+
+    struct TempProject {
+        path: PathBuf,
+    }
+    impl TempProject {
+        fn new() -> Self {
+            static N: AtomicUsize = AtomicUsize::new(0);
+            let id = N.fetch_add(1, Ordering::SeqCst);
+            let mut p = std::env::temp_dir();
+            p.push(format!("iter-cache-test-{}-{}", std::process::id(), id));
+            let _ = fs::remove_dir_all(&p);
+            fs::create_dir_all(&p).unwrap();
+            TempProject { path: p }
+        }
+    }
+    impl Drop for TempProject {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    #[test]
+    fn signature_changes_when_source_added_in_subdir() {
+        let tp = TempProject::new();
+        fs::write(tp.path.join("CMakeLists.txt"), "project(test)\n").unwrap();
+        let s0 = project_signature(&tp.path);
+
+        wait_mtime_tick();
+        let sub = tp.path.join("src");
+        fs::create_dir(&sub).unwrap();
+        fs::write(sub.join("main.cpp"), "int main() {}\n").unwrap();
+        let s1 = project_signature(&tp.path);
+        assert_ne!(
+            s0, s1,
+            "adding a relevant source in a sub-directory must change the signature"
+        );
+    }
+
+    #[test]
+    fn signature_unchanged_for_irrelevant_files() {
+        let tp = TempProject::new();
+        fs::write(tp.path.join("CMakeLists.txt"), "project(test)\n").unwrap();
+        let s0 = project_signature(&tp.path);
+
+        wait_mtime_tick();
+        fs::write(tp.path.join("README.md"), "hello\n").unwrap();
+        fs::write(tp.path.join("notes.txt"), "memo\n").unwrap();
+        let s1 = project_signature(&tp.path);
+        assert_eq!(
+            s0, s1,
+            "irrelevant files (README, notes) must not affect signature"
+        );
+    }
+
+    #[test]
+    fn signature_skips_blocklisted_directories() {
+        let tp = TempProject::new();
+        fs::write(tp.path.join("CMakeLists.txt"), "project(test)\n").unwrap();
+        let s0 = project_signature(&tp.path);
+
+        wait_mtime_tick();
+        for skip in &["node_modules", "target", ".git", "build", "dist"] {
+            let d = tp.path.join(skip);
+            fs::create_dir(&d).unwrap();
+            fs::write(d.join("foo.cpp"), "int x;\n").unwrap();
+        }
+        let s1 = project_signature(&tp.path);
+        assert_eq!(
+            s0, s1,
+            "blocklisted dirs (node_modules / target / .git / build / dist) must be skipped"
+        );
+    }
+
+    #[test]
+    fn signature_changes_when_source_modified() {
+        let tp = TempProject::new();
+        let src = tp.path.join("main.cpp");
+        fs::write(&src, "int x;\n").unwrap();
+        let s0 = project_signature(&tp.path);
+
+        wait_mtime_tick();
+        fs::write(&src, "int x; int y;\n").unwrap();
+        let s1 = project_signature(&tp.path);
+        assert_ne!(s0, s1, "modifying a tracked source must change signature");
     }
 }

--- a/src-tauri/src/lsp.rs
+++ b/src-tauri/src/lsp.rs
@@ -298,6 +298,58 @@ impl ClangdClient {
         Ok(serde_json::from_value(v).unwrap_or_default())
     }
 
+    /// `textDocument/definition`。 clangd は次のいずれかを返す:
+    ///   - `Location` (単体)
+    ///   - `Location[]`
+    ///   - `LocationLink[]` (originSelectionRange / targetUri / targetRange / targetSelectionRange)
+    /// すべて `Vec<Location>` に正規化する。 `LocationLink` は `targetSelectionRange`
+    /// を優先 (シンボル名ハイライト位置)、 無ければ `targetRange`。
+    pub async fn definitions(
+        &self,
+        uri: Uri,
+        position: Position,
+    ) -> Result<Vec<Location>, LspError> {
+        let params = TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier { uri },
+            position,
+        };
+        let v = self
+            .request(
+                "textDocument/definition",
+                serde_json::to_value(params).unwrap(),
+            )
+            .await?;
+
+        fn from_link(item: &Value) -> Option<Location> {
+            let target_uri = item.get("targetUri")?.as_str()?;
+            let range = item
+                .get("targetSelectionRange")
+                .or_else(|| item.get("targetRange"))?
+                .clone();
+            let uri: Uri = Uri::from_str(target_uri).ok()?;
+            let range: lsp_types::Range = serde_json::from_value(range).ok()?;
+            Some(Location { uri, range })
+        }
+
+        let locs: Vec<Location> = match &v {
+            Value::Array(arr) => arr
+                .iter()
+                .filter_map(|item| {
+                    serde_json::from_value::<Location>(item.clone())
+                        .ok()
+                        .or_else(|| from_link(item))
+                })
+                .collect(),
+            Value::Object(_) => serde_json::from_value::<Location>(v.clone())
+                .ok()
+                .or_else(|| from_link(&v))
+                .map(|loc| vec![loc])
+                .unwrap_or_default(),
+            _ => Vec::new(),
+        };
+        Ok(locs)
+    }
+
     async fn request(&self, method: &str, params: Value) -> Result<Value, LspError> {
         if self.is_dead() {
             return Err(LspError::Dead("clangd is not running".to_string()));

--- a/src-tauri/src/lsp_commands.rs
+++ b/src-tauri/src/lsp_commands.rs
@@ -137,6 +137,23 @@ pub async fn lsp_references(
         .map_err(|e| e.to_string())
 }
 
+/// 指定位置の symbol の宣言/定義位置を返す。 `textDocument/definition` ラッパ。
+/// FileWindow の `follow_definition` フラグ実装と graph node からの定義ジャンプで使う。
+#[tauri::command]
+pub async fn lsp_definitions(
+    state: tauri::State<'_, LspState>,
+    path: String,
+    line: u32,
+    character: u32,
+) -> Result<Vec<Location>, String> {
+    let client = require_client(&state).await?;
+    let uri = path_to_uri(&path)?;
+    client
+        .definitions(uri, lsp_types::Position { line, character })
+        .await
+        .map_err(|e| e.to_string())
+}
+
 fn path_to_uri(path: &str) -> Result<Uri, String> {
     let url = url::Url::from_file_path(path).map_err(|_| format!("invalid path: {path}"))?;
     Uri::from_str(url.as_str()).map_err(|e| format!("uri parse: {e}"))

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -24,7 +24,15 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": {
+        "default-src": "'self'",
+        "script-src": "'self'",
+        "style-src": ["'self'", "'unsafe-inline'"],
+        "img-src": ["'self'", "data:", "blob:"],
+        "font-src": ["'self'", "data:"],
+        "connect-src": ["'self'", "ipc:", "http://ipc.localhost"],
+        "worker-src": ["'self'", "blob:"]
+      }
     }
   },
   "bundle": {

--- a/src/FileWindow.tsx
+++ b/src/FileWindow.tsx
@@ -4,7 +4,7 @@ import { readTextFile, writeTextFile } from "@tauri-apps/plugin-fs";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import type * as Monaco from "monaco-editor";
-import { lsp, win, type CallHierarchyResult, type LspLocation } from "./lsp";
+import { lsp, win, uriToPath, type CallHierarchyResult, type LspLocation } from "./lsp";
 import { RelationGraph, type RelationData } from "./RelationGraph";
 
 interface Props {
@@ -217,9 +217,32 @@ export function FileWindow({ path, initialLine, initialCol, followDefinition }: 
       editor.setPosition({ lineNumber: ln, column: col });
       editor.focus();
       if (followDefinition) {
-        // 宣言を追跡: 最初に LSP definitions を取り、結果が別ファイルなら open_at
-        // (Phase 2 では definitions を未公開なので references の最初を流用)
-        // → 簡易実装: relation query を 1 度走らせるだけにとどめる
+        // LSP definitions を非同期で取り、 別位置/別ファイルへ自動ジャンプする。
+        // 同一ファイル内なら editor 内移動、 別ファイルなら open_at で新 window。
+        // 失敗しても元の位置に留まるだけで害なし。
+        void (async () => {
+          try {
+            const defs = await lsp.definitions(path, ln - 1, col - 1);
+            if (defs.length === 0) return;
+            const def = defs[0]!;
+            const targetPath = uriToPath(def.uri);
+            const targetLine = def.range.start.line + 1;
+            const targetCol = def.range.start.character;
+            const samePath =
+              targetPath.toLowerCase() === path.toLowerCase();
+            if (samePath) {
+              editor.revealLineInCenter(targetLine);
+              editor.setPosition({
+                lineNumber: targetLine,
+                column: targetCol + 1,
+              });
+            } else {
+              await win.openAt(targetPath, targetLine, targetCol);
+            }
+          } catch (err) {
+            console.warn("follow_definition failed:", err);
+          }
+        })();
       }
     }
 

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -76,6 +76,18 @@ export const lsp = {
   ): Promise<LspLocation[]> {
     return invoke<LspLocation[]>("lsp_references", { path, line, character });
   },
+  /**
+   * 指定位置のシンボルの宣言/定義位置を返す。 clangd の
+   * `textDocument/definition` ラッパ。 `follow_definition` ジャンプと
+   * graph node からのワンクリック定義移動で使う。
+   */
+  async definitions(
+    path: string,
+    line: number,
+    character: number,
+  ): Promise<LspLocation[]> {
+    return invoke<LspLocation[]>("lsp_definitions", { path, line, character });
+  },
   async parseStackTrace(text: string, projectRoot?: string): Promise<StackFrame[]> {
     return invoke<StackFrame[]>("parse_stack_trace", {
       text,


### PR DESCRIPTION
Closes M1, M2, M3 from #11 quality review.

## M2 — `textDocument/definition` (Go-to-definition)
- ClangdClient::definitions normalizes the union response (Location | Location[] | LocationLink[]) into Vec<Location>
- Tauri command `lsp_definitions` registered in lib.rs
- src/lsp.ts gains `lsp.definitions(path, line, char)`
- FileWindow's `followDefinition` flag is no longer a no-op: queries definitions on mount and jumps (in-editor if same file, `win.openAt` otherwise)

## M1 — Restrict CSP
- `csp: null` -> restrictive Tauri 2 baseline (script-src 'self', style-src + worker-src for Monaco, ipc in connect-src, image/font minimal data:/blob:)

## M3 — Signature-based cache invalidation
- Previous cache checked only root dir mtime (`cache.rs:71`) -> missed any sub-directory change
- New `project_signature` walks the project (max depth 8, skips node_modules/target/.git/build/dist/out/.iter/.cache/.vs/.idea), hashes (relative-path, mtime) over relevant file types only (C/C++/CMake/sln/vcxproj/csproj)
- Cache version 1 -> 2; v1 entries fall through to a fresh scan
- Tests: 4 new cache unit tests (subdir add, irrelevant files ignored, blocklisted dirs skipped, source modification detected)