### PR TITLE
feat(quality): isInProject util + shared project_root + criterion benches + DESIGN/ADR (M5-M8 from #11)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,83 @@
+# Iter — DESIGN
+
+ソースコードの関連性 (callers / callees / references) を AST 解析ベースで
+グラフ表示するデスクトップエディタ。 本書は v0.2.x 時点のアーキテクチャと、
+個別の設計決定 (ADR) の入口。
+
+## 一枚図
+
+```
+                       +-------------------------+
+                       | Control Panel (1 only)  |
+                       | - project picker        |
+                       | - file tree             |
+                       | - relation toggles      |
+                       | - stack-trace input     |
+                       +-----------+-------------+
+                                   | invoke()
+                                   v
++----------------------------------------------------------+
+| Tauri 2 backend (Rust)                                   |
+|                                                          |
+|   project::detect_project    --> cache::try_load/save    |
+|   compile_db::ensure_compile_commands --> .iter/         |
+|   lsp::ClangdClient (1 per project, async JSON-RPC)      |
+|   lsp_commands::*                                        |
+|   snippet::read_snippet                                  |
+|   stack_trace::parse_stack_trace                         |
+|   window::{open_file_window, open_at, close_others}      |
+|                                                          |
+|   shared state: LspState { client, project_root }        |
++----------------------------------------------------------+
+                                   ^
+                                   | invoke()
+                                   |
+                  +----------------+----------------+
+                  |                                 |
+                  v                                 v
+       +---------------------+         +-----------------------+
+       | File Window (N 個)  |         | File Window (N 個)    |
+       | - Monaco editor     | <-----> | - RelationGraph (xy)  |
+       | - search / save     |  open_  | - RelationCard nodes  |
+       | - follow_definition |  at()   |   (read_snippet 経由) |
+       +---------------------+         +-----------------------+
+```
+
+## レイヤ責務
+
+| レイヤ | 主な仕事 |
+|---|---|
+| **Control Panel** | プロジェクト選択 + ファイル一覧 + relation 表示 toggle + stack trace 入力 |
+| **File Window (multi)** | Monaco でファイル編集、検索、保存。 カーソル位置の relation 取得 → RelationGraph 描画 |
+| **Tauri commands** | OS 層 (file IO / 子プロセス) を frontend に公開する 1 単位 = 1 関数 |
+| **ClangdClient** | clangd プロセスとの JSON-RPC 双方向通信 + 死活監視 + stderr ring buffer |
+| **cache** | `<config_dir>/iter/projects/<hash>.json` で `detect_project` 結果を保持 |
+| **compile_db** | `compile_commands.json` を CMake で生成 or `.iter/` に仮想生成 |
+
+## 設計判断のインデックス (ADR)
+
+| # | テーマ | 要約 |
+|---|---|---|
+| [ADR-001](docs/adr/0001-tauri-2.md) | Tauri 2 を採用 | Electron 比で起動 / メモリ / セキュリティ全てで優位、 Rust IPC との親和性 |
+| [ADR-002](docs/adr/0002-clangd-lsp.md) | C/C++ 解析は clangd LSP | tree-sitter のみだと意味解析 (caller/callee 解決) が不足、 clangd の callHierarchy で済む |
+| [ADR-003](docs/adr/0003-react-flow.md) | グラフ描画は React Flow (@xyflow/react) | D3 直書きや Cytoscape 比で React コンポーネントとの統合が楽、 ノード = 自前 RelationCard を組める |
+| [ADR-004](docs/adr/0004-cache-signature.md) | キャッシュ妥当性は relevant-file mtime hash | root mtime だけだと sub-dir 変更を見逃す。 source 拡張子に限定して走査負荷を抑える |
+| [ADR-005](docs/adr/0005-multi-window.md) | File Window は **OS の子ウインドウ** (タブではなく) | Monaco + 関連グラフを並べて見るには独立ウインドウが効率的。 cross-window state は Rust 共有 + Tauri events |
+
+## ホットパス と コスト感覚 (criterion bench で計測)
+
+`cargo bench` で次の 2 系列を計測 (`src-tauri/benches/`):
+- `cache_signature` — 100 / 500 / 2000 ファイル規模
+- `snippet_read` — 1k / 100k 行 ファイル
+
+regression が出たら CI で検出する (ベースライン比較は今後 #11 の M7 follow-up で wire-in)。
+
+## 開発
+
+```bash
+npm install
+npm run tauri dev   # 初回は Rust 依存ビルドで数分
+npm test            # vitest (frontend)
+cargo test --manifest-path src-tauri/Cargo.toml  # Rust
+cargo bench --manifest-path src-tauri/Cargo.toml # criterion
+```

--- a/docs/adr/0001-tauri-2.md
+++ b/docs/adr/0001-tauri-2.md
@@ -1,0 +1,31 @@
+# ADR-001: ランタイムに Tauri 2 を採用
+
+**Status**: Accepted (2026-04, PR #4 で初期 scaffolding)
+
+## Context
+
+Iter はソースツリーをローカルで走査し、 clangd を子プロセスとして起動し、
+複数の OS ウインドウで Monaco エディタを並べて表示する必要がある。
+ランタイムの候補:
+
+| 候補 | 長所 | 短所 |
+|---|---|---|
+| **Electron** | エコシステム最大、 multi-window が容易 | バンドル 100MB+, 起動遅、 メモリ重、 子プロセス起動 OS 依存 |
+| **Tauri 2** | バイナリ < 10MB、 Rust 直叩き、 capability ベースのセキュリティ | エコシステム発展途上、 ネイティブ multi-window は v2 で初成熟 |
+| **Native (Qt, etc.)** | 完全制御 | C++ で再実装コスト高、 Monaco を埋めるのが大変 |
+
+## Decision
+
+Tauri 2 を採用。 主な理由:
+
+1. **Rust IPC**: clangd 駆動 / 子プロセス管理 / FS 走査が **同一言語の async fn** で完結する。 Electron だと Node 経由で重い。
+2. **multi-window**: v2 で WebView ごとの label / event 周りが整い、 `open_file_window` のような独立窓を低コストで作れる。
+3. **配布サイズと起動時間**: dev サーバ + Monaco を入れても初回起動 1-2 秒。
+4. **セキュリティ**: `capabilities/*.json` で fs / shell 等を細粒度に絞れる。 `csp: null` 禁止 (#11 M1) などの強制力がある。
+
+## Consequences
+
+- **+ Rust 経験必須** — Tauri command の追加には Rust 知識が要る。 small team では bus factor を意識。
+- **+ Vite frontend** — frontend dev サーバは普通の Vite で良い。 React, Monaco, @xyflow が素直に動く。
+- **- WebView 差** — Windows は WebView2, Linux は WebKitGTK, macOS は WKWebView。 Monaco / React Flow は問題ないが、 CSS / 一部 Web API で差が出ることがある。 CI で 3 OS 並走 (PR #12) で吸収。
+- **- IPC 帯域** — 大量データ (e.g. 数千 entry の relation) を invoke でやり取りすると遅い。 上限 100 件にトリムする `MAX_TOTAL_CARDS` (RelationGraph) を採用。

--- a/docs/adr/0002-clangd-lsp.md
+++ b/docs/adr/0002-clangd-lsp.md
@@ -1,0 +1,33 @@
+# ADR-002: C/C++ 関連解析は clangd LSP に委ねる
+
+**Status**: Accepted (2026-04, PR #5 で実装)
+
+## Context
+
+「caller / callee / references を取って graph で見せる」 が Iter のコアバリュー。
+解析手段の候補:
+
+| 候補 | できること | できないこと |
+|---|---|---|
+| **正規表現 / grep** | 即座、 軽量 | 同名関数の区別、 namespace 解決、 マクロ展開後の解析 |
+| **tree-sitter** | 高速、 構文木が取れる | **意味解析 (シンボル解決) を自前で書く必要**。 caller/callee 解決には型情報が必要で実装大変 |
+| **libclang 直叩き** | 完全な意味解析 | C++ AST API が複雑、 incremental が難しい |
+| **clangd (LSP)** | callHierarchy / references / definition が標準で揃う、 incremental 解析、 multi-file context | 別プロセス起動コスト、 compile_commands.json 必須 |
+
+## Decision
+
+**clangd を LSP として子プロセス起動** + `textDocument/*` を JSON-RPC で呼ぶ。
+
+- `prepareCallHierarchy` → `incomingCalls` / `outgoingCalls`
+- `references`
+- `definition` (PR #18 で実装、 #11 M2)
+
+`compile_commands.json` は `compile_db::ensure_compile_commands` が CMake (`-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`) で生成、 CMakeLists 不在時は `.iter/CMakeLists.txt` を仮想生成して fallback (PR #16)。
+
+## Consequences
+
+- **+ 意味解析の品質** — 同名関数のオーバーロード、 namespace、 inline、 マクロ展開後の caller も clangd が正しく解いてくれる。
+- **+ multi-language の入口** — 同じ LSP の上に rust-analyzer / typescript-language-server を後から差し替えできる (将来)。
+- **- clangd の起動コスト** — 数百 MB のインデックスを構築するので最初の `prepareCallHierarchy` まで数秒〜10 秒。 frontend は spinner で表現。
+- **- プロセス死活** — clangd が SIGSEGV する事象が稀にある。 PR #14 で watchdog + stderr piped を実装し `iter://lsp-down` イベントで UI に通知。
+- **- C++ 以外** — C# (.csproj/.sln) 検知は project.rs で対応するが clangd 対象外 (#15 でファイル覧覧のみ可)。 OmniSharp 等の追加は将来。

--- a/docs/adr/0003-react-flow.md
+++ b/docs/adr/0003-react-flow.md
@@ -1,0 +1,25 @@
+# ADR-003: グラフ描画に React Flow (`@xyflow/react`) を採用
+
+**Status**: Accepted (2026-04, PR #5)
+
+## Context
+
+「caller を上、 callee を下、 references を右」 のような関連を **ノードカードで** 表示したい。 ノードの中身は自前の `RelationCard` (パス / 行番号 / コードスニペット表示)。 候補:
+
+| 候補 | 長所 | 短所 |
+|---|---|---|
+| **D3 直書き** | 完全自由、 軽量 | React コンポーネントをノードに使えない、 layout 自分で実装 |
+| **Cytoscape.js** | 機能豊富、 layout 多数 | カスタムノードに自前 React を埋めるのが面倒、 styling は CSS-in-Cytoscape |
+| **React Flow (`@xyflow/react`)** | React コンポーネントをノードに使える、 自動 layout 不要なケースで超軽量、 v12 系で xyflow に rebrand | layout アルゴリズム (dagre 等) は追加が要る、 数千ノードで重くなる |
+| **Mermaid** | 設計図的描画にはベスト | 動的更新 / クリック interact が弱い |
+
+## Decision
+
+`@xyflow/react` (v12.3+) を採用。 `RelationCard` を `nodeTypes` に登録、 caller/callee は固定 layout (caller 群を上、 callee 群を下、 references を右) で配置。 layout アルゴリズム (dagre / ELK) は **入れない**。 トリム上限 `MAX_TOTAL_CARDS = 100` で大規模を回避。
+
+## Consequences
+
+- **+ React 統合** — `RelationCard.tsx` で素直に React/CSS を書ける。 hover / click / keyboard が普通の React イベント。
+- **+ 軽量初期構成** — 自動 layout 無しなので初期 bundle が小さい (`@xyflow/react` core のみ)。
+- **- 大規模 graph 不向き** — caller が 100 を超える場合は trim + 「+N more」 表示で済ます。 LSP / clangd 自体が遅くなる方が先にボトルネック。
+- **- layout は手動** — 関連の種類 (caller / callee / ref) を増やすときレイアウトロジックを足す必要。 これは関連が拡大したらタイミングを見て layout エンジン入れる候補。

--- a/docs/adr/0004-cache-signature.md
+++ b/docs/adr/0004-cache-signature.md
@@ -1,0 +1,37 @@
+# ADR-004: キャッシュ妥当性は relevant-file mtime ハッシュ
+
+**Status**: Accepted (2026-05, PR #18, #11 M3)
+
+## Context
+
+`detect_project` は plot しないと数千ファイルの走査で 1-3 秒かかる。
+キャッシュを `<config_dir>/iter/projects/<hash>.json` に置いて 2 回目以降を
+高速化したい。 問題は **キャッシュ無効化のキー** を何にするか:
+
+| 候補 | 長所 | 短所 |
+|---|---|---|
+| **root dir mtime のみ** | 計算 1 回、 ほぼ無料 | 子ディレクトリでファイル追加されても root mtime が変わらず stale を返す (実観測) |
+| **全ファイル mtime hash** | 完全正確 | node_modules / target を走査すると重い、 巨大 repo で seconds 単位 |
+| **relevant-file mtime hash** | 妥当性と速度のバランス | "relevant" の定義を維持するコストがある |
+| **inotify / fsevents 常時 watch** | 完全リアルタイム | 別途 watcher 常駐、 Tauri ライフサイクル管理が複雑 |
+
+## Decision
+
+**relevant-file mtime hash**。 `src-tauri/src/cache.rs:project_signature`:
+
+- 走査対象: `*.c / *.cc / *.cpp / *.cxx / *.h / *.hpp / *.hxx / *.cmake / *.sln / *.vcxproj / *.csproj / CMakeLists.txt`
+- skip dir: `node_modules / target / .git / .svn / .hg / dist / build / out / .iter / .cache / .vs / .idea`
+- 深さ上限 8 (現実的なリポは 5-6 階層)
+- symlink は cycle 防止で skip
+- root の mtime は **意図的に含めない** (README 追加で signature が変わってしまうのを避ける)
+- (relative-path, mtime) を path で sort してから hash → 順序非依存
+
+cache schema は v1 → v2 に bump。 古い v1 cache (`root_mtime_secs` キー) は version mismatch で破棄され、 fresh scan が走る。
+
+## Consequences
+
+- **+ 子ディレクトリ変更を検出** — 主たる pain point が解消。
+- **+ 無関係ファイルで無効化されない** — README / package.json / *.md の編集では cache が活きる。
+- **+ benchmark** — `src-tauri/benches/cache_signature.rs` で 100/500/2000 ファイル相当のコストを計測 (`cargo bench`)。
+- **- "relevant" 定義の保守** — 新言語サポート (Rust, Go 等) を入れる場合 `is_relevant_file` に追記が要る。
+- **- mtime resolution 依存** — Windows は 1 秒粒度、 1 秒以内の連続編集を取り逃す可能性。 実用上は問題なし (人間操作タイムスケールでは十分)。

--- a/docs/adr/0005-multi-window.md
+++ b/docs/adr/0005-multi-window.md
@@ -1,0 +1,31 @@
+# ADR-005: ファイルは「タブ」 ではなく **OS の独立 WebView ウインドウ**
+
+**Status**: Accepted (2026-04, PR #4)
+
+## Context
+
+VS Code / IntelliJ はファイルをタブで開く。 Iter のユースケースでは
+「caller を開いたまま callee の中身を見たい」 「関数本体と RelationGraph を
+横並びで見たい」 のような並べ替えが多い。 候補:
+
+| 候補 | 長所 | 短所 |
+|---|---|---|
+| **タブ式 (単一 window)** | 慣れた UX | 並列表示できない、 dual monitor 活用が難しい |
+| **分割ペイン** | 単一ウインドウ内で並列 | ペイン管理が複雑、 grid lock-in |
+| **独立ウインドウ (1 file = 1 window)** | OS のウインドウ管理に任せられる、 dual monitor 自然 | cross-window state が必要、 window 数管理 |
+
+## Decision
+
+**1 ファイル = 1 WebView ウインドウ**。 `window::open_file_window(path)` で開く。
+キャップは設けず、 `Ctrl+Shift+W` で「自分以外を全部閉じる」を提供 (`close_other_windows`)。
+
+cross-window で共有する state:
+- `project_root` → Rust 側 `LspState.project_root` (PR #18, #11 M6)
+- それ以外 (search state 等) は各 window 独立で OK
+
+## Consequences
+
+- **+ dual monitor 親和性** — caller を片方の画面、 callee をもう片方で見る運用が自然。
+- **+ Ctrl+Shift+W の単純さ** — 「整理したい」 を 1 ショートカットで実現できる。
+- **- ウインドウ間の同期** — `project_root` 1 つだけは Rust 共有 state にまとめる必要があった (#11 M6)。 future では「ファイル保存通知」 「LSP イベント」 も Tauri events 経由で全ウインドウに broadcast する予定。
+- **- 起動コスト** — 各ウインドウが WebView を立ち上げるので、 数十枚開くとメモリが嵩む。 ただし v0.2 段階では 10 枚程度の運用を想定。

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -42,6 +42,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,6 +270,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,6 +329,58 @@ dependencies = [
  "serde",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "combine"
@@ -397,6 +467,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,10 +512,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1235,6 +1366,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1266,6 +1408,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1575,9 +1723,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "iter"
 version = "0.2.0"
 dependencies = [
+ "criterion",
  "lsp-types",
  "serde",
  "serde_json",
@@ -1590,6 +1750,15 @@ dependencies = [
  "tokio",
  "url",
  "which",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -2138,6 +2307,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2410,6 +2585,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "png"
 version = "0.17.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2646,6 +2849,26 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -3771,6 +3994,16 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,6 +27,15 @@ which = "7"
 
 [dev-dependencies]
 tempfile = "3"
+criterion = { version = "0.5", features = ["html_reports"] }
 
 [features]
 custom-protocol = ["tauri/custom-protocol"]
+
+[[bench]]
+name = "cache_signature"
+harness = false
+
+[[bench]]
+name = "snippet_read"
+harness = false

--- a/src-tauri/benches/cache_signature.rs
+++ b/src-tauri/benches/cache_signature.rs
@@ -1,0 +1,50 @@
+//! `cache::project_signature` のベンチ。 100 / 500 / 2000 ファイル規模の
+//! プロジェクトでハッシュ計算がどれくらいで終わるかを確認する。
+//!
+//! signature は detect_project / try_load の頻繁に呼ぶホットパスなので、
+//! 大規模 repo (Linux kernel など) でも数百ミリ秒で済むことを担保したい。
+
+use std::fs;
+use std::path::Path;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use tempfile::TempDir;
+
+/// 同名関数を lib crate から再 export していないので、 私たちは bench に必要な
+/// 同等処理をここに再実装する代わりに、 ライブラリの公開 API を直接呼ぶ形にする
+/// (現状 `project_signature` は pub(crate) なので、 `cache::try_load` 経由で
+/// 内部的に signature を計算するパスをベンチ対象にする)。
+use iter_lib::cache;
+
+fn populate(root: &Path, n_files: usize) {
+    fs::write(root.join("CMakeLists.txt"), "project(bench)\n").unwrap();
+    // n_files を 50 dirs × M files に分散して collect_relevant の再帰負荷を作る
+    let per_dir = (n_files / 50).max(1);
+    for d in 0..50 {
+        let dir = root.join(format!("src/group_{:03}", d));
+        fs::create_dir_all(&dir).unwrap();
+        for f in 0..per_dir {
+            let path = dir.join(format!("file_{:04}.cpp", f));
+            fs::write(&path, "int x = 0;\n").unwrap();
+        }
+    }
+}
+
+fn bench_signature(c: &mut Criterion) {
+    for &n in &[100usize, 500, 2000] {
+        let tmp = TempDir::new().unwrap();
+        populate(tmp.path(), n);
+        let name = format!("project_signature/{}_files", n);
+        c.bench_function(&name, |b| {
+            b.iter(|| {
+                // signature が変わったかどうかだけ反映される 軽量パス: try_load は
+                // None を返すが、 その内部で project_signature を呼んでいる。
+                // 純粋な signature 計測のため、 cache 不在状態 (try_load が None) で測る。
+                let _: Option<serde_json::Value> = cache::try_load(tmp.path());
+            });
+        });
+    }
+}
+
+criterion_group!(benches, bench_signature);
+criterion_main!(benches);

--- a/src-tauri/benches/snippet_read.rs
+++ b/src-tauri/benches/snippet_read.rs
@@ -1,0 +1,46 @@
+//! `snippet::read_snippet` のベンチ。 中規模 (1000 行) と大規模 (10 万行) の
+//! ファイルから 50 行コンテキストを切り出すコストを測る。 graph node の
+//! プレビュー描画で連続コールされるホットパス。
+
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use tempfile::TempDir;
+
+use iter_lib::snippet;
+
+fn make_file(path: &Path, lines: usize) {
+    let mut f = fs::File::create(path).unwrap();
+    for i in 0..lines {
+        writeln!(f, "// line {:06} — some content here for testing", i + 1).unwrap();
+    }
+}
+
+fn bench_snippet(c: &mut Criterion) {
+    let tmp = TempDir::new().unwrap();
+    let small = tmp.path().join("small.cpp");
+    make_file(&small, 1_000);
+    let big = tmp.path().join("big.cpp");
+    make_file(&big, 100_000);
+
+    c.bench_function("read_snippet/1k_lines_at_500_ctx5", |b| {
+        b.iter(|| {
+            let _ = snippet::read_snippet(small.to_string_lossy().into_owned(), 500, 5);
+        });
+    });
+    c.bench_function("read_snippet/100k_lines_at_50000_ctx5", |b| {
+        b.iter(|| {
+            let _ = snippet::read_snippet(big.to_string_lossy().into_owned(), 50_000, 5);
+        });
+    });
+    c.bench_function("read_snippet/100k_lines_at_99000_ctx10", |b| {
+        b.iter(|| {
+            let _ = snippet::read_snippet(big.to_string_lossy().into_owned(), 99_000, 10);
+        });
+    });
+}
+
+criterion_group!(benches, bench_snippet);
+criterion_main!(benches);

--- a/src-tauri/src/cache.rs
+++ b/src-tauri/src/cache.rs
@@ -85,15 +85,6 @@ fn cache_path(root: &Path) -> Option<PathBuf> {
     Some(dir.join(format!("{:x}.json", h.finish())))
 }
 
-fn root_mtime_secs(root: &Path) -> u64 {
-    std::fs::metadata(root)
-        .and_then(|m| m.modified())
-        .ok()
-        .and_then(|t| t.duration_since(SystemTime::UNIX_EPOCH).ok())
-        .map(|d| d.as_secs())
-        .unwrap_or(0)
-}
-
 /// 走査対象とみなすファイル拡張子 + 特定ファイル名。 ここに無い拡張子は signature
 /// に寄与しない (= IDE の swap file / log 等の頻繁な変更で cache が無効化しないよう絞る)。
 fn is_relevant_file(path: &Path) -> bool {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -29,6 +29,8 @@ pub fn run() {
             lsp_commands::lsp_open_file,
             lsp_commands::lsp_call_hierarchy,
             lsp_commands::lsp_references,
+            lsp_commands::lsp_definitions,
+            lsp_commands::get_project_root,
             stack_trace::parse_stack_trace,
             snippet::read_snippet,
         ])

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,9 +1,12 @@
-mod cache;
+// `pub mod` for cache / snippet so the benchmark crate (under `benches/`) can
+// reach them as `iter_lib::cache::try_load` / `iter_lib::snippet::read_snippet`.
+// 他の module は内部利用に閉じるため private のまま。
+pub mod cache;
 mod compile_db;
 mod lsp;
 mod lsp_commands;
 mod project;
-mod snippet;
+pub mod snippet;
 mod stack_trace;
 mod window;
 

--- a/src-tauri/src/lsp_commands.rs
+++ b/src-tauri/src/lsp_commands.rs
@@ -154,6 +154,16 @@ pub async fn lsp_definitions(
         .map_err(|e| e.to_string())
 }
 
+/// 現在開いている project root を返す (`lsp_open_project` 後に set される)。
+/// cross-window 共有のため、 frontend は localStorage ではなくこちらを参照する。
+#[tauri::command]
+pub async fn get_project_root(
+    state: tauri::State<'_, LspState>,
+) -> Result<Option<String>, String> {
+    let guard = state.project_root.lock().await;
+    Ok(guard.as_ref().map(|p| p.to_string_lossy().into_owned()))
+}
+
 fn path_to_uri(path: &str) -> Result<Uri, String> {
     let url = url::Url::from_file_path(path).map_err(|_| format!("invalid path: {path}"))?;
     Uri::from_str(url.as_str()).map_err(|e| format!("uri parse: {e}"))

--- a/src/FileWindow.tsx
+++ b/src/FileWindow.tsx
@@ -4,7 +4,14 @@ import { readTextFile, writeTextFile } from "@tauri-apps/plugin-fs";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import type * as Monaco from "monaco-editor";
-import { lsp, win, uriToPath, type CallHierarchyResult, type LspLocation } from "./lsp";
+import {
+  lsp,
+  win,
+  uriToPath,
+  getProjectRoot,
+  type CallHierarchyResult,
+  type LspLocation,
+} from "./lsp";
 import { RelationGraph, type RelationData } from "./RelationGraph";
 
 interface Props {
@@ -297,14 +304,29 @@ export function FileWindow({ path, initialLine, initialCol, followDefinition }: 
     return () => window.removeEventListener("keydown", onKey);
   }, []);
 
+  // project_root を Rust 共有 state から取得 (cross-window で同じ値を見る単一情報源)。
+  // 失敗時は legacy の localStorage に fallback (ControlPanel が detect 時に書き込む)。
+  const [projectRoot, setProjectRoot] = useState<string | null>(() =>
+    typeof window !== "undefined" ? localStorage.getItem(PROJECT_ROOT_KEY) : null,
+  );
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const r = await getProjectRoot();
+        if (!cancelled && r) setProjectRoot(r);
+      } catch {
+        // LSP 未起動なら null。 localStorage fallback を維持
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   if (!path) {
     return <div className="fw-error">path クエリが指定されていません</div>;
   }
-
-  // project_root はセッション間で共有できないので localStorage 経由
-  // (ControlPanel が detect 時に保存するように Phase 2.5 で拡張予定)
-  const projectRoot =
-    typeof window !== "undefined" ? localStorage.getItem(PROJECT_ROOT_KEY) : null;
 
   return (
     <div className="fw-shell-2">

--- a/src/RelationGraph.tsx
+++ b/src/RelationGraph.tsx
@@ -13,6 +13,7 @@ import { useEffect, useMemo, useState } from "react";
 import { ReactFlow, Background, Controls, type Node, type Edge } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { fs, type CallHierarchyResult, type LspLocation, uriToPath } from "./lsp";
+import { isInProject } from "./utils";
 import {
   RelationCard,
   ensureCardStyles,
@@ -317,8 +318,4 @@ function makeEdge(
   };
 }
 
-function isInProject(path: string, root: string | null): boolean {
-  if (!root) return true;
-  const norm = (s: string) => s.replace(/\\/g, "/").toLowerCase();
-  return norm(path).startsWith(norm(root));
-}
+// isInProject は src/utils.ts に切り出し済 (重複を避けるため)。

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -96,6 +96,15 @@ export const lsp = {
   },
 };
 
+/**
+ * 現在開いている project の root path を Rust shared state から取得する。
+ * `lsp_open_project` 後にのみ非 null。 cross-window で同じ値を見るための単一情報源。
+ */
+export async function getProjectRoot(): Promise<string | null> {
+  const r = await invoke<string | null>("get_project_root");
+  return r ?? null;
+}
+
 export const win = {
   async openFileWindow(path: string): Promise<void> {
     await invoke("open_file_window", { path });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,20 @@
+/**
+ * cross-component で共有する小さな utility 群。
+ *
+ * - `isInProject`: 与えられた path が project root 配下かを大文字小文字 + path
+ *   separator 非依存で判定。 root が null の場合は「project が未確定」とみなして
+ *   true を返す (= グラフ上の node を pre-mark しない、 safe default)。
+ */
+
+/**
+ * path が project root 配下かを判定する。
+ *
+ * - root が null/空: 判定不能 → true (= フィルタリング無効、 safe default)
+ * - 大文字小文字を無視 (Windows 大文字小文字非区別の volume を想定)
+ * - `\` と `/` を統一して比較
+ */
+export function isInProject(path: string, root: string | null): boolean {
+  if (!root) return true;
+  const norm = (s: string) => s.replace(/\\/g, "/").toLowerCase();
+  return norm(path).startsWith(norm(root));
+}


### PR DESCRIPTION
Closes M5, M6, M7, M8 of #11 quality review in one PR.

## M5 — Hoist isInProject
`src/utils.ts` is the single owner of the case-insensitive path-prefix check; RelationGraph / FileWindow no longer carry duplicates.

## M6 — Project root via Rust shared state
New tauri command `get_project_root` exposes `LspState.project_root` so FileWindow no longer reads localStorage as primary source. localStorage stays as a legacy fallback for when LSP isn't running.

## M7 — Criterion benches
- `benches/cache_signature.rs` — 100/500/2000 files
- `benches/snippet_read.rs` — 1k / 100k lines

`cache` and `snippet` become `pub mod` so the bench crate can reach them.

## M8 — Architecture docs
- `DESIGN.md` — top-level overview + ADR index
- `docs/adr/0001..0005` — Tauri 2 / clangd / React Flow / cache signature / multi-window choices