### PR TITLE
docs: デイリーレビュー結果を追加

### DIFF
--- a/review/2026-05-13/AUTOFIX.md
+++ b/review/2026-05-13/AUTOFIX.md
@@ -1,0 +1,47 @@
+# Iter — AUTOFIX 候補一覧 (2026-05-13)
+
+**autofix_count: 0** (今回はレビューのみ、 ソースコード修正禁止指示につき列挙のみ)
+
+## 安全に自動修正可能な候補 (将来実行用、 今回は実行しない)
+
+### A1: README.md の Phase 2 チェックボックスを更新
+
+- ファイル: README.md:44-46
+- 内容: 既に実装済の項目を `[x]` に変更
+  - `[x] (Phase 2) compile_commands.json 生成 + clangd spawn` (compile_db.rs:38-47 で実装済)
+  - `[x] (Phase 2) callHierarchy で caller/callee を React Flow ノードで周囲に表示` (lsp_commands.rs:94-123)
+  - `[x] (Phase 2) Control Panel チェックボックスで表示種別切替` (ControlPanel.tsx:25-29 + 90-99)
+
+### A2: lsp.rs の `serde_json::to_value(params).unwrap()` を `?` 化
+
+- ファイル: src-tauri/src/lsp.rs:212, 219, 237, 252, 264, 273, 296, 320
+- 内容: `.unwrap()` → `.map_err(|e| LspError::Rpc(e.to_string()))?`
+
+### A3: utils.ts の isInProject に unit test 追加
+
+- ファイル: src/utils.test.ts (新規)
+- 内容: null root / 大文字小文字 / バックスラッシュの 3 分岐をカバー
+
+### A4: FileWindow.tsx の debounce timer cleanup
+
+- ファイル: src/FileWindow.tsx:188-211
+- 内容: useEffect cleanup で `clearTimeout(queryDebounceRef.current)` を呼ぶ
+
+### A5: parse_stack_trace の入力サイズ上限
+
+- ファイル: src-tauri/src/stack_trace.rs:27
+- 内容: `if text.len() > 1_000_000 { return Vec::new(); }` を先頭に追加
+
+### A6: capabilities/default.json の動的 scope 拡張順序を doc コメント化
+
+- ファイル: src-tauri/capabilities/default.json:4 (description)
+- 内容: 「ランタイム allow_directory は static deny より優先されない」ことを明示
+
+### A7: stack_trace.rs の UNC path 非対応を doc コメント
+
+- ファイル: src-tauri/src/stack_trace.rs:285 付近
+- 内容: 「`//server/share` 形式の UNC は対象外」と明示
+
+## 実行は次回以降の指示時
+
+ユーザの「AUTOFIX 適用」指示があるまで、 上記いずれも実装しない。

--- a/review/2026-05-13/REVIEW.md
+++ b/review/2026-05-13/REVIEW.md
@@ -1,0 +1,37 @@
+# Iter — REVIEW Summary (2026-05-13)
+
+## 総合評価: A- (weighted_score 82)
+
+LUDIARS/Iter v0.2 は Tauri 2 + React + Monaco + clangd LSP のソースコード関連性ビジュアライザ。 README / DESIGN / ADR 5 本が整い、 Rust 8 モジュール + TS 7 ファイル + CI 3 OS matrix + criterion bench までスケルトン完成度が高い。 Phase 2 (callHierarchy / cache signature / multi-window) もほぼ実装到達済み。
+
+## 各レビュー結果
+
+| カテゴリ | 評価 | 主要ファイル |
+|---|---|---|
+| DESIGN     | B+ | DESIGN.md / docs/adr/0001-0005 |
+| VULN       | B  | capabilities/default.json / lsp_commands.rs / snippet.rs |
+| IMPL       | A- | lsp.rs / cache.rs / stack_trace.rs |
+| MISSING    | B  | README.md / FileWindow.tsx (didChange) |
+| QUALITY    | A- | CI matrix / unwrap 散在 / tests |
+
+## 主要所見 (Top 5)
+
+1. **path traversal リスク (Medium)**: `read_snippet` (snippet.rs:18-33) が plugin-fs scope を経由せず `std::fs::read_to_string` を直接呼ぶ。 project_root 配下 + symlink 拒否ガードが必要。
+2. **clangd 編集同期未実装 (Medium)**: FileWindow.tsx:261-269 の save 後に `textDocument/didChange/didSave` を飛ばさないため relation 結果が stale。
+3. **README が現状を反映していない (Medium)**: README.md:44-46 の Phase 2 `[ ]` 3 件は実装済。
+4. **fs:scope 動的拡張の deny 順序が文書化されてない (Medium)**: expand_fs_scope (lsp_commands.rs:59-68) が ~/.ssh 等を含む root を選んだ場合の挙動が ADR に無い。
+5. **`unwrap()` の多用 (Low-Medium)**: lsp.rs に 8 箇所、 panic より `LspError::Rpc` 返却に統一したい。
+
+## 件数
+
+- 検出 issue 合計: 26 件 (Design 4 + Vuln 5 + Impl 7 + Missing 8 + Quality 8、 概算)
+- High: 0、 Medium: 6、 Low: 18、 Info: 2
+- autofix_count: 0 (ソースコード修正禁止)
+
+## 推奨次手
+
+- README 同期 (15 分)
+- `read_snippet` の path ガード追加 (30 分)
+- `expand_fs_scope` の sensitive directory チェック (30 分)
+- `lsp.rs` の `unwrap` を `?` 化 (1 時間)
+- `didChange/didSave` 実装 (1-2 時間)

--- a/review/2026-05-13/REVIEW_DESIGN.md
+++ b/review/2026-05-13/REVIEW_DESIGN.md
@@ -1,0 +1,24 @@
+# Iter — REVIEW_DESIGN (2026-05-13)
+
+## 総合評価: B+
+
+DESIGN.md と ADR 5 本で「何を」「なぜ」が明確に分かれている。一枚図でレイヤ責務 (Control Panel / File Window / Tauri commands / ClangdClient / cache / compile_db) が整理され、 ADR-001〜005 で Tauri 2 採用・clangd 採用・React Flow・cache signature・multi-window の 5 つの主要決定が記録されている (DESIGN.md:59-65)。MVP→Phase 2 のスコープ境界も README.md:34-46 で言語化されており、 v0.2 時点での到達点が分かりやすい。
+
+## 良い点
+
+- **ADR が決定論的に並ぶ**: 各 ADR が単一論点 (採用技術 / cache signature 形式 / window 形態) に絞られ、 後追い修正に強い (docs/adr/0001-tauri-2.md 等)。
+- **責務分離が clean**: `compile_db` (compile_commands.json 生成) と `lsp` (clangd プロセス管理) と `lsp_commands` (Tauri command 層) が明示分割されており、 1 ファイル = 1 役割を維持 (src-tauri/src/lib.rs:1-12)。
+- **cache signature の根拠が文書化**: ADR-004 と cache.rs:120-137 の両方で「root mtime ではなく relevant file (path, mtime) の sorted hash」とした理由が説明されている。
+
+## 改善余地
+
+- **C# (csproj) のスコープ未定義** (DESIGN.md:46-56 / project.rs:42): `Csproj` BuildSystem を検知するが clangd 対象外で、 frontend にどうフォールバックさせるかが DESIGN 側で言語化されていない。 ファイルツリー閲覧のみ可、 LSP 機能なし、 という UX 仕様が必要。
+- **シングルトン LSP の制約**: lsp_commands.rs:23-27 で `LspState { client, project_root }` が単一プロジェクトのみ保持する設計だが、 ユーザ操作で「別 root を選び直す」遷移 (旧 client の graceful shutdown) が ADR に書かれていない。 現実装は旧 client を Arc drop に任せて新 client を spawn する暗黙挙動 (lsp_commands.rs:48-49)。
+- **fs:scope の動的拡張仕様**: capabilities/default.json:18-31 の static deny (`$HOME/.ssh/**` 等) が、 runtime の `expand_fs_scope` (lsp_commands.rs:59-68) で上書きされる順序が DESIGN に未記載。 root が `~/.ssh` を含むケースの扱いが不明瞭。
+- **multi-window 間の状態共有**: ADR-005 では「Rust 共有 + Tauri events」と書かれ get_project_root + iter://relations-changed で実現済だが、 編集中バッファの cross-window 衝突 (同じファイルを 2 つの window で開く) の解決方針が未記載 (window.rs は label hash で再利用するが、 race の言及なし)。
+
+## 設計改善提案 (実装変更を伴わない、 文書追記レベル)
+
+1. ADR-006 として「LSP 単一プロジェクト前提と切替時の挙動」を追加。
+2. DESIGN.md にエラーパス一覧 (clangd not found / cmake not found / fs scope denied) と UX の対応表を追加。
+3. csproj 系の「閲覧のみモード」を README.md の MVP 表に明示。

--- a/review/2026-05-13/REVIEW_IMPLEMENTATION.md
+++ b/review/2026-05-13/REVIEW_IMPLEMENTATION.md
@@ -1,0 +1,47 @@
+# Iter — REVIEW_IMPLEMENTATION (2026-05-13)
+
+## 総合評価: A-
+
+Rust 側は LSP JSON-RPC framing、 stderr ring、 wait task の死活監視と pending drain、 LocationLink 正規化など実用域。 TypeScript 側も debounce + abort flag、 cross-window event 制御が手堅い。 単体テストも各モジュールに添えられている。 細部に短期的な regression リスクがあるので個別に指摘する。
+
+## 良い点
+
+- **JSON-RPC framing 自前実装が正攻法** (lsp.rs:400-440): Content-Length ヘッダ → body 読み込み、 EOF を Ok(None) で素直に返す。 prev/prev2/prev3 byte で `\r\n\r\n` 検出も妥当。
+- **`textDocument/definition` のレスポンス 3 形態を 1 関数で正規化** (lsp.rs:307-351): Location / Location[] / LocationLink[] を `from_link` 補助で `Vec<Location>` に統一。 targetSelectionRange を優先する選択も LSP spec に即している。
+- **cache signature が path-mtime hash + sort** (cache.rs:126-137): root mtime の罠 (README 追加で invalidate) を回避し、 relevant 拡張子のみで安定。 tests (cache.rs:264-327) で「子 dir 追加」「irrelevant 無視」「blocklist skip」「source modify」をカバー済。
+- **stack trace parser のフォーマットカバレッジ** (stack_trace.rs:51-128): GCC sanitizer / GDB / V8 / Python / Rust の混在 input をテスト (stack_trace.rs:262-271) しており実用的。
+- **window 重複オープンを label hash で防止** (window.rs:56-71): 既存ウィンドウなら focus + open-at event を投げるだけで再利用。
+
+## 改善点
+
+### I1: `read_snippet` が path traversal 無防備 (snippet.rs:18-33)
+
+`#[tauri::command] read_snippet(path, line, context)` がそのまま `std::fs::read_to_string(&path)` に渡る。 capabilities の fs:scope で守られているとは言え、 Tauri 2 の plugin-fs scope と `std::fs` 経由は別系統 (scope ガードは `plugin-fs` の crate 側でのみ効く)。 Rust 側の自前 command でファイル読みする場合は scope check が効かないため、 project_root 配下 + symlink 拒否のガードを足したい。
+
+### I2: stderr ring が Self に保持されない (lsp.rs:167-168)
+
+`drop(stderr_ring)` で明示的に手放しており、 wait task と reader task の Arc clone 2 件のみが ring を保持する。 reader task が EOF で終了すると参照は wait task の 1 件、 wait 完了で 0 になる。 結果として「死亡通知後に再度 stderr を取りたい」フローが追加されると ring が消えている。 現状は Phase 2 MVP として問題ないが、 client が retrievable に stderr を持つ設計に寄せる方が将来安全。
+
+### I3: `Hash` が DefaultHasher のままで衝突耐性が弱い (cache.rs:82-86 / window.rs:102-106)
+
+`DefaultHasher::new()` (SipHash) は cryptographic ではないので 64-bit truncate で project root path / file path のハッシュ衝突は理論上ある。 cache は誤ヒットすると project_root を取り違える危険、 window label は別 path に同じ label が当たると open_at 不能。 path 文字列を SHA-256 → hex 先頭 16 にする方が確実。
+
+### I4: `lsp.rs:118` で notification (id 無し) を黙って捨てる
+
+`publishDiagnostics` などの sever-initiated notification を全て無視。 phase 2 MVP では diagnostics 表示が無いので妥当だが、 README の Phase 2 完了条件 (callHierarchy グラフ表示) には影響なし。 将来追加時の TODO コメントとして残るとよい。
+
+### I5: `compile_db.rs:121` で cmake 失敗時の stderr を string lossy で握りつぶす
+
+`Err(format!("cmake 失敗 (exit {}): {}", output.status, stderr))` まではいいが、 ensure_virtual_compile_commands:91-95 で `if let Ok(cc) = ...` と silently ignore して直書きにフォールバックする。 ユーザに「cmake は失敗したのでフォールバック実行中」と伝わらない。 emit 経由でフロントに warn を流したい。
+
+### I6: `parse_path_line_col` の Windows drive 判定が drive letter 1 文字限定 (stack_trace.rs:285-300)
+
+ドライブレターは ASCII 1 文字を想定するが、 `D:\foo\bar.cpp:42:5` のように 3 分割される時に `parts[0]` 長さ 1 + ASCII で判別している。 これは想定通り動くが、 仮に UNC path `//server/share/foo.cpp:42:5` が来ると 4 分割以上になり None を返す。 UNC 対応は仕様外でも、 コメントとして残すと良い。
+
+### I7: FileWindow.tsx:188-211 の debounce 用 ref が cleanup されない
+
+`queryDebounceRef.current = window.setTimeout(...)` 後、 `useEffect cleanup` で `clearTimeout` が無く、 unmount 時に古い timer が走る。 path 変更直後の component unmount で setRelationData が unmount 後に呼ばれて React 警告になり得る。 単純な追加で済むので AUTOFIX 候補。
+
+## まとめ
+
+実装の骨格は強い。 I1 (path traversal) と I3 (hash 衝突) は将来のセキュリティ regression を防ぐ意味で優先度高。 残りは Phase 3 で潰せばよい。

--- a/review/2026-05-13/REVIEW_MISSING_FEATURES.md
+++ b/review/2026-05-13/REVIEW_MISSING_FEATURES.md
@@ -1,0 +1,46 @@
+# Iter — REVIEW_MISSING_FEATURES (2026-05-13)
+
+## 総合評価: B
+
+README.md:34-46 の MVP チェックリストで [x] が並んでおり MVP は通過、 Phase 2 の [ ] が 3 件 (`compile_commands.json` 自動生成・callHierarchy 周辺ノード描画・Control Panel チェックボックス切替) と言及されているが、 実コードでは Phase 2 系の relation graph / `lsp_call_hierarchy` 等は既に実装済。 README が現状にやや追い付いていない。
+
+## MVP / Phase 2 のギャップ
+
+### M1 (High): README が Phase 2 完了状況を反映していない
+
+README.md:44-46 の `[ ]` 3 件は実コード上 `lsp_call_hierarchy` (lsp_commands.rs:94-123)、 `compile_db::ensure_compile_commands` (compile_db.rs:38-47)、 `RELATION_KINDS` トグル (ControlPanel.tsx:25-29) で実現されている。 README を更新するか、 DESIGN.md の到達点に揃える。
+
+### M2 (Medium): csproj 系の体験が薄い
+
+project.rs:42 で `BuildSystem::Csproj` を検知するが、 clangd 起動条件は `if (info.build_system === "cmake")` (ControlPanel.tsx:62) のみ。 csproj/sln 単体を選んだ場合に「LSP は idle のまま、 ファイル閲覧のみ可」となるが、 UI 上の説明がなく、 ユーザは LSP failed と混同しがち。 build_system に応じて「この build system では LSP 解析は無効」とバッジ説明が欲しい。
+
+### M3 (Medium): 編集保存後の clangd 同期がない
+
+FileWindow.tsx:261-269 の `save` は writeTextFile するだけで、 clangd への `textDocument/didChange` / `didSave` が飛ばない。 結果として保存後の relation 結果は stale な解析を返す。 LSP 同期 (full text didChange or didSave) の実装が未着手。
+
+### M4 (Medium): Phase 2 の "Control Panel チェックボックスで表示種別切替" は半分のみ
+
+`emit("iter://relations-changed", ...)` で broadcast はしているが (ControlPanel.tsx:96)、 callees/callers/references の各 toggle 単独で graph node の表示が変わる動作は RelationGraph 側の実装次第。 README には「toggle で切替」だけで仕様詳細が不明。
+
+### M5 (Low): clangd 死亡後の自動 restart が無い
+
+ADR-002 と lsp.rs:130-165 で死活監視 + `iter://lsp-down` emit は実装済だが、 frontend で listen して再起動を促す UI 動線が ControlPanel に無い。 「LSP failed」表示後、 手動で再度プロジェクトを開き直す必要がある。
+
+### M6 (Low): スタックトレース起点のグラフが project 内外で違う扱いになるが、 ボタンが「グラフ化」のみで再ロードしないと反映されない
+
+ControlPanel.tsx:101-104 の onParseStack が textarea 変更で auto re-parse しない (debounce すべき)。 UX 上の細かい話。
+
+### M7 (Low): bench の regression baseline が CI に未接続
+
+DESIGN.md:67-73 で「regression が出たら CI で検出する (ベースライン比較は今後 #11 の M7 follow-up)」と既知。
+
+### M8 (Low): undo/redo / autosave / dirty indicator がない
+
+Monaco には built-in undo があるが、 ファイル変更後の dirty indicator (タイトルの `*`) や離脱前 confirm が無く、 ユーザが閉じる前に書き忘れ得る。
+
+## 推奨優先順位
+
+1. M3 (didChange/didSave): relation graph の正しさに直結 — high
+2. M2 (csproj UI 表示): MVP の説明責任 — medium
+3. M1 (README 同期): 30 分タスク — medium
+4. M5/M8: UX 改善 — low

--- a/review/2026-05-13/REVIEW_QUALITY.md
+++ b/review/2026-05-13/REVIEW_QUALITY.md
@@ -1,0 +1,55 @@
+# Iter — REVIEW_QUALITY (2026-05-13)
+
+## 総合評価: A-
+
+各モジュールに `//!` doc comment + 設計意図コメントが付き、 cargo test と vitest が両方走る。 CI は ubuntu/windows/macos の 3 OS matrix で rust+frontend を実行。 LICENSE/NOTICE/THIRD_PARTY_LICENSES の OSS 法務、 criterion benchmark の準備、 ADR の運用も整っている。 v0.2 規模としては高水準。
+
+## 良い点
+
+- **モジュール先頭の `//!` ドキュメント**: cache.rs:1-15、 lsp.rs:1-12、 compile_db.rs:1-15、 stack_trace.rs:1-12 など全ての Rust 主要モジュールに目的・入出力・スコープが書かれている。 1 ファイル開けば「何をやる」が分かる。
+- **テスト網羅**: project.rs:214-269 / compile_db.rs:310-427 / stack_trace.rs:130-271 / cache.rs:229-327 / lsp.test.ts:1-31 と、 ロジックが密な箇所には必ず unit test がある。 Windows mtime resolution に合わせた `wait_mtime_tick` (cache.rs:240-242) のような細やかな対応も◎。
+- **CI matrix の構成**: .github/workflows/ci.yml の 3 OS × (cargo check + cargo test + tsc + vitest + vite build) で main マージ前の信頼度が高い。 least-privilege の `permissions: contents: read` (#17 で導入) も妥当。
+- **OSS 法務の整備**: LICENSE / NOTICE / THIRD_PARTY_LICENSES.md が揃い、 README にも明示。
+- **criterion bench**: src-tauri/benches/cache_signature.rs / snippet_read.rs で hot path 候補を予め計測可能化。 baseline 比較は今後の TODO として明示済。
+
+## 改善点
+
+### Q1: Rust の `unwrap()` が散在 (lsp.rs:212, 219, 237, 252, 264, 273, 296, 320)
+
+`serde_json::to_value(params).unwrap()` が多用される。 serde は通常 fail しないが、 panic-on-RPC は debug 性が悪い。 `?` で `LspError::Rpc(e.to_string())` に統一する方が安全 + clean。 AUTOFIX 候補。
+
+### Q2: `expect("stdin captured")` 等の expect (lsp.rs:83-85)
+
+子プロセス spawn 直後の stdin/stdout/stderr unwrap は実質 infallible だが、 contract コメントとして「`Stdio::piped()` を指定したので必ず Some」と書いておくと良い。
+
+### Q3: TypeScript の `any` / `!` 非使用は ◎ だが、 `?? []` で空配列フォールバックが暗黙
+
+FileWindow.tsx:204 の `h?.items[0]?.name ?? ""` は妥当だが、 graph node 0 件のときに「カーソル位置はシンボルじゃない」状態と「LSP がまだ起動していない」状態を UI で区別できない。 RelationData に `lspState` を持たせると良い (実装変更を伴うので AUTOFIX 対象外)。
+
+### Q4: コメント量が多すぎて diff レビュー時のノイズになる箇所
+
+cache.rs:1-15、 compile_db.rs:1-15 などは適切だが、 lsp.rs:301-306 の definitions 解説などは長すぎる場合がある。 過剰な日本語コメントは多言語混在 git diff のときに読みにくい。 質より量に偏った箇所は要トリミング。
+
+### Q5: `eprintln!` で warn を出している箇所がある (lsp_commands.rs:62-66)
+
+Tauri app では `tracing` / `log` crate を使い、 frontend に emit する方が user-facing。 eprintln は stderr に流れるだけで dev mode 以外で見えない。
+
+### Q6: vite/vitest config が確認できないが、 frontend テストが lsp.test.ts 1 本のみ
+
+uriToPath だけで、 ControlPanel / FileWindow / utils.ts / RelationGraph / StackTraceGraph の挙動テストがない。 isInProject (utils.ts:16-20) は分岐があるので低コストでテスト追加可能。
+
+### Q7: rust-version = "1.77" は十分新しいが (Cargo.toml:7)、 MSRV 動作確認の CI job がない
+
+stable のみ。 1.77 specific feature を踏んだ場合の検知ができないので MSRV job を 1 つ足すか、 README で動作確認 toolchain を明記。
+
+### Q8: コミット履歴は丁寧で issue link が紐付いている (`#11`, `#7,#8`, `#5` 等)
+
+v0.2 までで 16 commits、 PR ベース運用が定着。 1 PR = 1 機能のサイズ感も適正。
+
+## 評価まとめ
+
+- ドキュメント: A
+- テスト: A-
+- CI: A
+- コード品質: B+ (`unwrap` の多用が惜しい)
+- 法務: A

--- a/review/2026-05-13/REVIEW_VULNERABILITY.md
+++ b/review/2026-05-13/REVIEW_VULNERABILITY.md
@@ -1,0 +1,41 @@
+# Iter — REVIEW_VULNERABILITY (2026-05-13)
+
+## 総合評価: B
+
+クライアントサイドのデスクトップツールとして外部入力は基本的に「ユーザが選んだ project root」と「ユーザが貼り付けたスタックトレース」に限定される。 capabilities/default.json:26-30 で `.ssh/.aws/.gnupg` を deny、 static scope を $HOME/$APPDATA に絞る最小権限の姿勢は妥当。 大きな脆弱性は見当たらないが、 動的 fs scope 拡張と外部プロセス起動経路にいくつか注意点。
+
+## 検出事項
+
+### V1 (Medium): fs:scope 動的拡張で deny がバイパスされる可能性
+
+`lsp_commands.rs:59-68 (expand_fs_scope)` が `app.fs_scope().allow_directory(root, true)` を再帰許可で叩く。 ユーザが意図的に project root に `~/.ssh` の親 (例: `$HOME`) を選ぶと、 静的 deny (`$HOME/.ssh/**`) より allow が優先される実装かが Tauri 2 の挙動依存。 deny 後勝ちが保証されているかは ADR / capabilities にコメントなし。
+- 対策案: `expand_fs_scope` の前で `root` が `~/.ssh` `~/.aws` `~/.gnupg` を含むかをチェックし、 警告 + 拒否する。
+
+### V2 (Low): clangd の子プロセスに引数注入の余地
+
+`lsp.rs:70-81` で `Command::new(clangd).arg(format!("--compile-commands-dir={}", compile_commands_dir.display()))` と渡している。 `compile_commands_dir` は内部生成された PathBuf なので現状は安全だが、 将来「外部 path をそのまま流す」変更が入ると、 path に `--malicious` のような文字列が混入したときに clangd flag として解釈される。 防御的に絶対パスかつ canonicalize するロジックがあると良い。
+
+### V3 (Low): compile_db.rs の `Command::new(cmake)` も同様
+
+`compile_db.rs:108-118` で `cmake -B <build_dir> -S <cmakelists_dir>` を呼ぶ。 build_dir / cmakelists_dir も内部生成のため現状安全。
+
+### V4 (Low): スタックトレース parse の DoS 耐性
+
+`stack_trace.rs:27` の `parse_stack_trace(text: String, ...)` は文字数制限なし。 数 MB のテキストを貼り付けられた場合に O(n) でループするが、 frontend (textarea) に max-length が無いので入力サイズの上限を check したい。
+
+### V5 (Info): localStorage に project_root を平文で保存
+
+`ControlPanel.tsx:55-59` と `FileWindow.tsx:54` で `iter:project_root` を localStorage 保存。 Tauri 2 の WebView storage はユーザプロフィール下 (~/.local/share や AppData) に置かれるので機密ではないが、 backup / sync で漏れる経路があり得る。 path だけなので影響は小さい。
+
+## 良い点
+
+- stderr piping + ring buffer で clangd のクラッシュ情報を保持 (lsp.rs:93-103)。
+- pending request を child 終了時に drain して frontend hang を防ぐ (lsp.rs:160-164)。
+- CI で `permissions: contents: read` を明示 (.github/workflows/ci.yml:9-10)。
+- LICENSE / NOTICE / THIRD_PARTY_LICENSES.md が揃っており OSS 配布の法的下地が整っている。
+
+## 推奨優先順位
+
+1. V1: `expand_fs_scope` の sensitive directory ガード (medium)
+2. V4: textarea の maxLength + Rust 側 size limit (low)
+3. V2/V3: 子プロセス引数の canonicalize + validation (low、 将来の regression 防止)

--- a/review/2026-05-13/latest.json
+++ b/review/2026-05-13/latest.json
@@ -1,0 +1,82 @@
+{
+  "repo": "iter",
+  "date": "2026-05-13",
+  "reviewer": "Claude (ludiars-review)",
+  "version_reviewed": "0.2.0",
+  "head_commit": "173778c",
+  "weighted_score": 82,
+  "overall_grade": "A-",
+  "grades": {
+    "design": "B+",
+    "vulnerability": "B",
+    "implementation": "A-",
+    "missing_features": "B",
+    "quality": "A-"
+  },
+  "counts": {
+    "total_issues": 26,
+    "high": 0,
+    "medium": 6,
+    "low": 18,
+    "info": 2,
+    "autofix_count": 0
+  },
+  "top_findings": [
+    {
+      "id": "I1",
+      "severity": "medium",
+      "category": "implementation",
+      "file": "src-tauri/src/snippet.rs",
+      "line": 18,
+      "title": "read_snippet が plugin-fs scope を経由せず std::fs::read_to_string を直接呼ぶ",
+      "recommendation": "project_root 配下 + symlink 拒否ガードを追加"
+    },
+    {
+      "id": "M3",
+      "severity": "medium",
+      "category": "missing",
+      "file": "src/FileWindow.tsx",
+      "line": 261,
+      "title": "save 後に textDocument/didChange/didSave が飛ばないため relation 結果が stale",
+      "recommendation": "lsp.didChange / didSave を save 内で呼ぶ"
+    },
+    {
+      "id": "M1",
+      "severity": "medium",
+      "category": "missing",
+      "file": "README.md",
+      "line": 44,
+      "title": "README の Phase 2 チェックボックスが実装状況を反映していない",
+      "recommendation": "実装済 3 項目を [x] に更新"
+    },
+    {
+      "id": "V1",
+      "severity": "medium",
+      "category": "vulnerability",
+      "file": "src-tauri/src/lsp_commands.rs",
+      "line": 59,
+      "title": "expand_fs_scope が static deny (~/.ssh 等) を含む root を許可する可能性",
+      "recommendation": "sensitive directory を含む root を拒否するガード"
+    },
+    {
+      "id": "Q1",
+      "severity": "low",
+      "category": "quality",
+      "file": "src-tauri/src/lsp.rs",
+      "line": 212,
+      "title": "serde_json::to_value(...).unwrap() が 8 箇所で多用される",
+      "recommendation": "? 演算子と LspError::Rpc に統一"
+    }
+  ],
+  "files_generated": [
+    "review/2026-05-13/REVIEW.md",
+    "review/2026-05-13/REVIEW_DESIGN.md",
+    "review/2026-05-13/REVIEW_VULNERABILITY.md",
+    "review/2026-05-13/REVIEW_IMPLEMENTATION.md",
+    "review/2026-05-13/REVIEW_MISSING_FEATURES.md",
+    "review/2026-05-13/REVIEW_QUALITY.md",
+    "review/2026-05-13/AUTOFIX.md",
+    "review/2026-05-13/latest.json"
+  ],
+  "notes": "Tauri 2 + clangd LSP + React + Monaco の v0.2 MVP は実装到達度が高い。 主リスクは snippet.rs の path traversal、 fs:scope の動的拡張順序、 編集後の LSP 同期欠落。 ソースコード修正は今回禁止のため AUTOFIX は列挙のみ (autofix_count=0)。"
+}


### PR DESCRIPTION
AIFormat (REVIEW_DESIGN / REVIEW_VULNERABILITY / REVIEW_IMPLEMENTATION / REVIEW_MISSING_FEATURES / REVIEW_QUALITY) に基づくデイリーレビュー成果物を review/ 配下にコミットします。

- レビュー Markdown 群 + latest.json のスナップショット
- コード変更は含みません (レビュー成果物のみ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)