### PR TITLE
ci: pin workflow actions by commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         working-directory: src-tauri
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Linux dependencies
         if: matrix.os == 'ubuntu-latest'
@@ -35,9 +35,9 @@ jobs:
             librsvg2-dev \
             libssl-dev
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           workspaces: src-tauri
 
@@ -56,9 +56,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -12,6 +12,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   harness:
-    uses: LUDIARS/AIFormat/.github/workflows/harness-checks.yml@main
+    uses: LUDIARS/AIFormat/.github/workflows/harness-checks.yml@b67d1063dbc857ab619b01ba35f7b979b07691ba # AIFormat harness


### PR DESCRIPTION
## Summary
- Pin every GitHub Action and reusable-workflow reference to a full commit SHA with version comments.
- Add the minimum read-only `contents` permission to the AIFormat harness workflow.
- Pin the AIFormat harness revision to `b67d1063dbc857ab619b01ba35f7b979b07691ba`.

## Why
Mutable action tags and reusable-workflow branches can change outside this repository's review process.

## Impact
The CI triggers, 3-OS matrix, and existing commands are unchanged.

## Validation
- Workflow static checks: passed (five full-SHA references, explicit permissions, preserved matrix and commands).
- `cargo test --all-targets --locked --offline`: passed (30 tests).
- Node dependencies are absent in this worktree; they were not installed per scope.